### PR TITLE
Fix :Tags command tagfile relative path

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -437,7 +437,7 @@ function! fzf#vim#tags(...)
     let copt = '--ansi '
   endif
   call s:fzf({
-  \ 'source':  proc.shellescape(tagfile),
+  \ 'source':  proc.shellescape(fnamemodify(tagfile, ':t')),
   \ 'dir':     fnamemodify(tagfile, ':h'),
   \ 'options': copt.'+m --tiebreak=begin --prompt "Tags> "'.s:expect(),
   \ 'sink*':   function('s:tags_sink')}, a:000)


### PR DESCRIPTION
Since fzf will execute the source command in the tagfile's directory, we
can't give the path of the tagfile relative to the current working
directory. Instead give just the filename.