### PR TITLE
Pull out the git log command as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ let g:fzf_action = {
 " - window (nvim only)
 let g:fzf_layout = { 'down': '~40%' }
 
+" For Commits and BCommits to customize the options used by 'git log':
+let g:fzf_commits_log_options = '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
+
 " Advanced customization using autoload functions
 autocmd VimEnter * command! Colors
   \ call fzf#vim#colors({'left': '15%', 'options': '--reverse --margin 30%,0'})

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -729,7 +729,7 @@ function! s:commits(buffer_local, args)
     return s:warn('Not in git repository')
   endif
 
-  let source = 'git log --graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
+  let source = 'git log '.get(g:, 'fzf_commits_log_options', '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"')
   let current = expand('%:S')
   let managed = 0
   if !empty(current)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -115,7 +115,7 @@ But its functionality is still available via `call pathogen#helptags()`.)
 < Customization >_____________________________________________________________~
                                                          *fzf-vim-customization*
 
-                                                     *g:fzf_action* *g:fzf_layout*
+                           *g:fzf_action* *g:fzf_layout* *g:fzf_commits_log_options*
 >
     " This is the default extra key bindings
     let g:fzf_action = {
@@ -125,6 +125,10 @@ But its functionality is still available via `call pathogen#helptags()`.)
 
     " Default fzf layout
     let g:fzf_layout = { 'down': '40%' }
+
+    " For Commits and BCommits to customize the options used by 'git log':
+    let g:fzf_commits_log_options = \
+        '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
 
     " Advanced customization using autoload functions
     autocmd VimEnter * command! Colors


### PR DESCRIPTION
In my environment '--graph' is a kiss of death. It results in seeing
nothing but graph lines due to the number of branches in the environment.

Secondly the colors baked into this break with my color scheme
which has a background of black rending the date unreadable.

I pulled it out as an option to just specify the command. This might be too flexible but it was an easy solution for me.  I just add to my ``.vimrc``:

```
let g:fzf_commit_log_command = 'git log --color=always --format="%C(auto)%h%d %s %C(blue)%C(bold)%cr"'
```