### PR TITLE
fzf#vim#buffer_tags([tag commands], options)

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -432,14 +432,12 @@ endfunction
 " ------------------------------------------------------------------
 " BTags
 " ------------------------------------------------------------------
-function! s:btags_source()
+function! s:btags_source(tag_cmds)
   if !filereadable(expand('%'))
     throw 'Save the file first'
   endif
 
-  for cmd in [
-    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s', &filetype, expand('%:S')),
-    \ printf('ctags -f - --sort=no --excmd=number %s', expand('%:S'))]
+  for cmd in a:tag_cmds
     let lines = split(system(cmd), "\n")
     if !v:shell_error
       break
@@ -476,12 +474,17 @@ function! s:btags_sink(lines)
   normal! zz
 endfunction
 
+" [tag commands], options
 function! fzf#vim#buffer_tags(...)
+  let args = copy(a:000)
+  let tag_cmds = len(args) > 1 ? remove(args, 0) : [
+    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s', &filetype, expand('%:S')),
+    \ printf('ctags -f - --sort=no --excmd=number %s', expand('%:S'))]
   try
     return s:fzf(fzf#vim#wrap({
-    \ 'source':  s:btags_source(),
+    \ 'source':  s:btags_source(tag_cmds),
     \ 'sink*':   s:function('s:btags_sink'),
-    \ 'options': '--reverse -m -d "\t" --with-nth 1,4.. -n 1 --prompt "BTags> "'}), a:000)
+    \ 'options': '--reverse -m -d "\t" --with-nth 1,4.. -n 1 --prompt "BTags> "'}), args)
   catch
     return s:warn(v:exception)
   endtry


### PR DESCRIPTION
Added ability to specify the commands used to generate tags
Some filetypes have better tag generators than ctags. For example, Javascript has jsctags which found all the functions in a file while ctags found 4.

This change lets you set the BTags command to use whatever commands you want to generate tags.
```
autocmd FileType javascript command! -buffer BTags
  \ call fzf#vim#buffer_tags([
    \ printf('jsctags %s -f', expand('%:S')),], {})
```


These changes are based on https://github.com/junegunn/fzf.vim/commit/0ad88dd4e8136e7eed48c27937a1f55efe0bc69c