### PR TITLE
Add `Filetypes` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Commands
 | `Commands`       | Commands                                                                  |
 | `Maps`           | Normal mode mappings                                                      |
 | `Helptags`       | Help tags <sup id="a1">[1](#helptags)</sup>                               |
+| `Filetypes`      | File types
 
 - Most commands support `CTRL-T` / `CTRL-X` / `CTRL-V` key
   bindings to open in a new tab, a new split, or in a new vertical split

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -714,6 +714,18 @@ function! fzf#vim#helptags(...)
 endfunction
 
 " ------------------------------------------------------------------
+" File types
+" ------------------------------------------------------------------
+function! fzf#vim#filetypes(...)
+  return s:fzf({
+  \ 'source':  sort(map(split(globpath(&rtp, 'syntax/*.vim'), '\n'),
+  \            'fnamemodify(v:val, ":t:r")')),
+  \ 'sink':    'setf',
+  \ 'options': '+m --prompt="File types> "'
+  \}, a:000)
+endfunction
+
+" ------------------------------------------------------------------
 " Windows
 " ------------------------------------------------------------------
 function! s:format_win(tab, win, buf)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -95,6 +95,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `Commands`        | Commands
   `Maps`            | Normal mode mappings
   `Helptags`        | Help tags [1]
+  `Filetypes`       | File types
  -----------------+-------------------------------------------------------------------
 
  - Most commands support CTRL-T / CTRL-X / CTRL-V key bindings to open in a new

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -60,6 +60,7 @@ call s:defs([
 \'command! -bang Commits                       call fzf#vim#commits(s:w(<bang>0))',
 \'command! -bang BCommits                      call fzf#vim#buffer_commits(s:w(<bang>0))',
 \'command! -bang Maps                          call fzf#vim#maps("n", s:w(<bang>0))',
+\'command! -bang Filetypes                     call fzf#vim#filetypes(s:w(<bang>0))',
 \'command! -bang -nargs=* History              call s:history(<q-args>, <bang>0)'])
 
 function! s:history(arg, bang)


### PR DESCRIPTION
This pull request introduces a new command that allows you to search through the various valid file types.

It essentially fixes the issue I created here: https://github.com/junegunn/fzf.vim/issues/109.