### PR TITLE
Setting to prevent automatic tag generation.

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -579,11 +579,16 @@ function! s:tags_sink(lines)
 endfunction
 
 function! fzf#vim#tags(query, ...)
+  let generate_tags = get(g:, 'fzf_generate_tags', 1)
   if empty(tagfiles())
-    call s:warn('Preparing tags')
-    call system('ctags -R')
-    if empty(tagfiles())
-      return s:warn('Failed to create tags')
+    if generate_tags
+      call s:warn('Preparing tags')
+      call system('ctags -R')
+      if empty(tagfiles())
+        return s:warn('Failed to create tags')
+      endif
+    else
+      return s:warn('No tags found')
     endif
   endif
 

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -156,6 +156,9 @@ Command-local options~
     " [[B]Commits] to customize the options used by 'git log':
     let g:fzf_commits_log_options = \
         '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
+
+    " [Tags] Prevent tag generation if no tagfiles found.
+    let g:fzf_generate_tags = 0
 <
 
 Advanced customization using autoload functions~


### PR DESCRIPTION
I'm currently using [vim-gutentags](https://github.com/ludovicchabant/vim-gutentags) to manage my tagfiles and would like to prevent fzf.vim from trying to create them for me.

I've added the following setting that can disable that behavior:

    let g:fzf_generate_tags = 0

