### PR TITLE
removed unneeded slice

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -206,7 +206,7 @@ function! s:line_handler(lines)
   endif
 
   let keys = split(a:lines[1], '\t')
-  execute 'buffer' keys[0][1:-2]
+  execute 'buffer' keys[0]
   execute keys[1][0:-2]
   normal! ^zz
 endfunction


### PR DESCRIPTION
Hi there! 
There's a small bug in FZFLines that prevents jumping to line found in another buffer. I've removed the slicing and now it works ok.