### PR TITLE
Fix fzf#vim#complete#line with new bufname display

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -250,7 +250,7 @@ function! fzf#vim#_lines(all)
     call extend(b == buf ? cur : rest,
     \ filter(
     \   map(lines,
-    \       '(!a:all && empty(v:val)) ? "" : printf(s:blue("%2d\t", "TabLine")."%s".s:yellow("\t%4d ", "LineNr")."\t%s\t", b, bufname, v:key + 1, v:val)'),
+    \       '(!a:all && empty(v:val)) ? "" : printf(s:blue("%2d\t", "TabLine")."%s".s:yellow("\t%4d ", "LineNr")."\t%s", b, bufname, v:key + 1, v:val)'),
     \   'a:all || !empty(v:val)'))
   endfor
   return extend(cur, rest)

--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -136,14 +136,15 @@ endfunction
 " <plug>(fzf-complete-buffer-line)
 " ----------------------------------------------------------------------------
 function! s:reduce_line(lines)
-  return join(split(a:lines[0], '\t\zs')[2:], '')
+  return join(split(a:lines[0], '\t\zs')[3:], '')
 endfunction
+
 
 function! fzf#vim#complete#line(...)
   return fzf#vim#complete(s:extend({
   \ 'prefix':  '^.*$',
   \ 'source':  fzf#vim#_lines(0),
-  \ 'options': '--tiebreak=index --ansi --nth 3..',
+  \ 'options': '--tiebreak=index --ansi --nth 4..',
   \ 'reducer': s:function('s:reduce_line')}, get(a:000, 0, g:fzf#vim#default_layout)))
 endfunction
 


### PR DESCRIPTION
This has been broken in 397a2e6.