### PR TITLE
[vim] handle 'nowrapscan' option in s:tags_sink

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -602,7 +602,7 @@ function! s:tags_sink(lines)
   normal! m'
   let qfl = []
   let cmd = get(get(g:, 'fzf_action', s:default_action), a:lines[0], 'e')
-  let [magic, &magic] = [&magic, 0]
+  let [magic, &magic, wrapscan, &wrapscan] = [&magic, 0, &wrapscan, 1]
   for line in a:lines[1:]
     let parts = split(line, '\t\zs')
     let excmd = matchstr(join(parts[2:], ''), '^.*\ze;"\t')
@@ -610,7 +610,7 @@ function! s:tags_sink(lines)
     execute excmd
     call add(qfl, {'filename': expand('%'), 'lnum': line('.'), 'text': getline('.')})
   endfor
-  let &magic = magic
+  let [&magic, &wrapscan] = [magic, wrapscan]
   if len(qfl) > 1
     call setqflist(qfl)
     copen


### PR DESCRIPTION
With 'nowrapscan' a tag might not be found, depending of the position in
the file.