### PR TITLE
Add g:fzf_ag_raw option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ let g:fzf_commits_log_options = '--graph --color=always --format="%C(auto)%h%d %
 
 " [Tags] Command to generate tags file
 let g:fzf_tags_command = 'ctags -R'
+
+" [Ag] Command to use raw input, although --nogroup --column --color is still
+applied
+let g:fzf_ag_raw = 1
 ```
 
 #### Advanced customization using autoload functions

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -515,18 +515,20 @@ function! s:ag_handler(lines)
   endif
 endfunction
 
-" query, [[ag options], options]
+function! s:ag_cmd(query)
+  let raw = get(g:, "fzf_ag_raw", 0)
+  return 'ag --nogroup --column --color ' .
+        \ (raw ? a:query : printf('"%s"', escape(empty(a:query) ? '^(?=.)' : a:query, '"\-')))
+endfunction
+
+" query, options
 function! fzf#vim#ag(query, ...)
-  let args = copy(a:000)
-  let ag_opts = len(args) > 1 ? remove(args, 0) : ''
   return s:fzf(fzf#vim#wrap({
-  \ 'source':  printf('ag --nogroup --column --color %s "%s"',
-  \                   ag_opts,
-  \                   escape(empty(a:query) ? '^(?=.)' : a:query, '"\-')),
+  \ 'source': s:ag_cmd(a:query),
   \ 'sink*':    s:function('s:ag_handler'),
   \ 'options': '--ansi --delimiter : --nth 4..,.. --prompt "Ag> " '.
   \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.
-  \            '--color hl:68,hl+:110'}), args)
+  \            '--color hl:68,hl+:110'}), a:000)
 endfunction
 
 " ------------------------------------------------------------------

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -49,7 +49,7 @@ call s:defs([
 \'command! -bang BLines                        call fzf#vim#buffer_lines(s:w(<bang>0))',
 \'command! -bang Colors                        call fzf#vim#colors(s:w(<bang>0))',
 \'command! -bang -nargs=1 -complete=dir Locate call fzf#vim#locate(<q-args>, s:w(<bang>0))',
-\'command! -bang -nargs=* Ag                   call fzf#vim#ag(<q-args>, s:w(<bang>0))',
+\'command! -bang -nargs=* -complete=dir Ag     call fzf#vim#ag(<q-args>, s:w(<bang>0))',
 \'command! -bang -nargs=* Tags                 call fzf#vim#tags(<q-args>, s:w(<bang>0))',
 \'command! -bang -nargs=* BTags                call fzf#vim#buffer_tags(<q-args>, s:w(<bang>0))',
 \'command! -bang Snippets                      call fzf#vim#snippets(s:w(<bang>0))',


### PR DESCRIPTION
Don't know how to set search path with Ag, it's also not convenient to pass extra option. So i make a little change.  Default Ag behavior is unchanged  except now -complete=dir
You can toggle on ag raw input by
```Vim
let g:fzf_ag_raw = 1
```
Although old codes will break if you use function to pass extra option to Ag. But i think people who pass extra options should be used to ag default behavior. 

By the way, i like your job. With fzf, i don't need ctrlp, tagbar, Ag.vim anymore, and everything is so fast.