### PR TITLE
Open selected target with ctrl-o

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -118,7 +118,8 @@ endfunction
 let s:default_action = {
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
-  \ 'ctrl-v': 'vsplit' }
+  \ 'ctrl-v': 'vsplit',
+  \ 'ctrl-o': 'edit' }
 
 function! s:open(cmd, target)
   if stridx('edit', a:cmd) == 0 && fnamemodify(a:target, ':p') ==# expand('%:p')


### PR DESCRIPTION
I moved from ctrl-p to fzf and liked this behavior there. You browse results with `ctrl-j/k` and open the current one with `ctrl-o`