### PR TITLE
Added AgHistory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,30 +47,31 @@ Plug 'junegunn/fzf.vim'
 Commands
 --------
 
-| Command          | List                                                                      |
-| ---              | ---                                                                       |
-| `Files [PATH]`   | Files (similar to `:FZF`)                                                 |
-| `GitFiles`       | Git files                                                                 |
-| `Buffers`        | Open buffers                                                              |
-| `Colors`         | Color schemes                                                             |
-| `Ag [PATTERN]`   | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all)   |
-| `Lines`          | Lines in loaded buffers                                                   |
-| `BLines`         | Lines in the current buffer                                               |
-| `Tags [QUERY]`   | Tags in the project (`ctags -R`)                                          |
-| `BTags [QUERY]`  | Tags in the current buffer                                                |
-| `Marks`          | Marks                                                                     |
-| `Windows`        | Windows                                                                   |
-| `Locate PATTERN` | `locate` command output                                                   |
-| `History`        | `v:oldfiles` and open buffers                                             |
-| `History:`       | Command history                                                           |
-| `History/`       | Search history                                                            |
-| `Snippets`       | Snippets ([UltiSnips][us])                                                |
-| `Commits`        | Git commits (requires [fugitive.vim][f])                                  |
-| `BCommits`       | Git commits for the current buffer                                        |
-| `Commands`       | Commands                                                                  |
-| `Maps`           | Normal mode mappings                                                      |
-| `Helptags`       | Help tags <sup id="a1">[1](#helptags)</sup>                               |
-| `Filetypes`      | File types
+| Command               | List                                                                    |
+| ---                   | ---                                                                     |
+| `Files [PATH]`        | Files (similar to `:FZF`)                                               |
+| `GitFiles`            | Git files                                                               |
+| `Buffers`             | Open buffers                                                            |
+| `Colors`              | Color schemes                                                           |
+| `Ag [PATTERN]`        | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all) |
+| `AgHistory [PATTERN]` | Similar to Ag but search in v:oldfiles instead of cwd                   |
+| `Lines`               | Lines in loaded buffers                                                 |
+| `BLines`              | Lines in the current buffer                                             |
+| `Tags [QUERY]`        | Tags in the project (`ctags -R`)                                        |
+| `BTags [QUERY]`       | Tags in the current buffer                                              |
+| `Marks`               | Marks                                                                   |
+| `Windows`             | Windows                                                                 |
+| `Locate PATTERN`      | `locate` command output                                                 |
+| `History`             | `v:oldfiles` and open buffers                                           |
+| `History:`            | Command history                                                         |
+| `History/`            | Search history                                                          |
+| `Snippets`            | Snippets ([UltiSnips][us])                                              |
+| `Commits`             | Git commits (requires [fugitive.vim][f])                                |
+| `BCommits`            | Git commits for the current buffer                                      |
+| `Commands`            | Commands                                                                |
+| `Maps`                | Normal mode mappings                                                    |
+| `Helptags`            | Help tags <sup id="a1">[1](#helptags)</sup>                             |
+| `Filetypes`           | File types
 
 - Most commands support `CTRL-T` / `CTRL-X` / `CTRL-V` key
   bindings to open in a new tab, a new split, or in a new vertical split

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -356,6 +356,25 @@ function! fzf#vim#history(...)
 endfunction
 
 " ------------------------------------------------------------------
+" AgHistory
+" ------------------------------------------------------------------
+
+" query, [[ag options], options]
+function! fzf#vim#aghistory(query, ...)
+  let args = copy(a:000)
+  let ag_opts = len(args) > 1 ? remove(args, 0) : ''
+  return s:fzf(fzf#vim#wrap({
+  \ 'source':  printf('ag --nogroup --column --color %s "%s" %s',
+  \                   ag_opts,
+  \                   escape(empty(a:query) ? '^(?=.)' : a:query, '"\-'),
+  \                   join(s:all_files())),
+  \ 'sink*':    s:function('s:ag_handler'),
+  \ 'options': '--ansi --delimiter : --nth 4..,.. --prompt "AgHist> " '.
+  \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.
+  \            '--color hl:68,hl+:110'}), args)
+endfunction
+
+" ------------------------------------------------------------------
 " GitFiles
 " ------------------------------------------------------------------
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -419,7 +419,7 @@ function! fzf#vim#aghistory(query, ...)
   \ 'source':  printf('ag --nogroup --column --color %s "%s" %s',
   \                   ag_opts,
   \                   escape(empty(a:query) ? '^(?=.)' : a:query, '"\-'),
-  \                   join(s:all_files())),
+  \                   join(s:all_files_no_buffers())),
   \ 'sink*':    s:function('s:ag_handler'),
   \ 'options': '--ansi --delimiter : --nth 4..,.. --prompt "AgHist> " '.
   \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -406,11 +406,16 @@ endfunction
 " AgHistory
 " ------------------------------------------------------------------
 
+function! s:all_files_no_buffers()
+  return filter(reverse(copy(v:oldfiles)),
+  \        "v:val !~ 'fugitive:\\|__Tagbar__\\|NERD_tree\\|^/tmp/\\|\\.git/\\|term://'")
+endfunction
+
 " query, [[ag options], options]
 function! fzf#vim#aghistory(query, ...)
   let args = copy(a:000)
   let ag_opts = len(args) > 1 ? remove(args, 0) : ''
-  return s:fzf(fzf#vim#wrap({
+  return s:fzf('aghistory', fzf#vim#wrap({
   \ 'source':  printf('ag --nogroup --column --color %s "%s" %s',
   \                   ag_opts,
   \                   escape(empty(a:query) ? '^(?=.)' : a:query, '"\-'),

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -47,7 +47,7 @@ call s:defs([
 \'command! -bang Colors                        call fzf#vim#colors(fzf#vim#layout(<bang>0))',
 \'command! -bang -nargs=1 -complete=dir Locate call fzf#vim#locate(<q-args>, fzf#vim#layout(<bang>0))',
 \'command! -bang -nargs=* Ag                   call fzf#vim#ag(<q-args>, fzf#vim#layout(<bang>0))',
-\'command! -bang -nargs=* AgHistory            call fzf#vim#aghistory(<q-args>, s:w(<bang>0))',
+\'command! -bang -nargs=* AgHistory            call fzf#vim#aghistory(<q-args>, fzf#vim#layout(<bang>0))',
 \'command! -bang -nargs=* Tags                 call fzf#vim#tags(<q-args>, fzf#vim#layout(<bang>0))',
 \'command! -bang -nargs=* BTags                call fzf#vim#buffer_tags(<q-args>, fzf#vim#layout(<bang>0))',
 \'command! -bang Snippets                      call fzf#vim#snippets(fzf#vim#layout(<bang>0))',

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -50,6 +50,7 @@ call s:defs([
 \'command! -bang Colors                        call fzf#vim#colors(s:w(<bang>0))',
 \'command! -bang -nargs=1 -complete=dir Locate call fzf#vim#locate(<q-args>, s:w(<bang>0))',
 \'command! -bang -nargs=* Ag                   call fzf#vim#ag(<q-args>, s:w(<bang>0))',
+\'command! -bang -nargs=* AgHistory            call fzf#vim#aghistory(<q-args>, s:w(<bang>0))',
 \'command! -bang -nargs=* Tags                 call fzf#vim#tags(<q-args>, s:w(<bang>0))',
 \'command! -bang -nargs=* BTags                call fzf#vim#buffer_tags(<q-args>, s:w(<bang>0))',
 \'command! -bang Snippets                      call fzf#vim#snippets(s:w(<bang>0))',


### PR DESCRIPTION
I've added the AgHistory command which is similar to the Ag command except that it searches through the contents of `v:old_files` (not just the filenames in `v:old_files`).

This essentially adds a "grep recent files" use case.

Please critique my implementation, Is there a better way to do with with the existing `fzf#vim#ag()` function?