### PR TITLE
[GFiles?] include all untracked files

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -420,7 +420,7 @@ function! fzf#vim#gitfiles(args, ...)
   " We're trying to access the common sink function that fzf#wrap injects to
   " the options dictionary.
   let wrapped = fzf#wrap({
-  \ 'source':  'git -c color.status=always status --short',
+  \ 'source':  'git -c color.status=always status --short --untracked-files=all',
   \ 'dir':     root,
   \ 'options': '--ansi --multi --nth 2..,.. --prompt "GitFiles?> " --preview ''(git diff --color=always -- {-1} | sed 1,4d; cat {-1}) | head -500'''
   \})


### PR DESCRIPTION
By default git-status won't include new files in new directories.

E.g.

    foo/bar/baz.txt # "baz.txt" is a new file in a new directory "bar".

    $ git status --short
    ?? foo/bar/