### PR TITLE
[Ag] add preview window when ag something

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -505,7 +505,7 @@ endfunction
 " ------------------------------------------------------------------
 " Ag
 " ------------------------------------------------------------------
-let s:fzf_ag_preview = expand('<sfile>:h:h').'/../bin/ag_preview'
+let s:preview_bin = expand('<sfile>:h:h').'/../bin/ag_preview'
 
 function! s:ag_to_qf(line, with_column)
   let parts = split(a:line, ':')
@@ -581,13 +581,21 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   \            '--color hl:68,hl+:110'
   \}
 
-  if executable(s:fzf_ag_preview)
-    let opts.options = opts.options.' --preview-window=right:49% --preview="'.s:fzf_ag_preview.' {1} {2}"'
-  end
   function! opts.sink(lines)
     return s:ag_handler(a:lines, self.column)
   endfunction
   let opts['sink*'] = remove(opts, 'sink')
+  return call('fzf#vim#preview', extend([name, opts], a:000))
+endfunction
+
+" ag preview command name, options, [...]
+function! fzf#vim#preview(name, options, ...)
+  let name = a:name
+  let opts = a:options
+
+  if executable(s:preview_bin)
+    let opts.options = opts.options.' --preview-window=right:50% --preview="'.s:preview_bin.' {1} {2}"'
+  end
   return s:fzf(name, opts, a:000)
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -571,12 +571,23 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   let name    = join(words, '-')
   let capname = join(map(words, 'toupper(v:val[0]).v:val[1:]'), '')
   let textcol = a:with_column ? '4..' : '3..'
+  let lines        = get(g:, 'fzf_ag_match_context', 5)
+  let preview_opts = get(g:, 'fzf_ag_preview_options', 'right:49%')
+  let preview_cmd  = "' line={2}; dlines=".lines.';'.
+  \                  '  minl=$((line-dlines)); maxl=$((line+dlines));'.
+  \                  '  [[ "${minl}" -lt 1 ]] && minl=1;'.
+  \                  '  cat -n {1} | awk -v min="${minl}" -v max="${maxl}" -v line="${line}" "{'.
+  \                  '    if (NR >= min && NR <= max) {'.
+  \                  '      if (NR == line) { printf \"\033[4m\"; }'.
+  \                  '      print; printf \"\033[0m\";'.
+  \                  '    }'.
+  \                  '  }"'."'"
   let opts = {
   \ 'source':  a:grep_command,
   \ 'column':  a:with_column,
   \ 'options': '--ansi --delimiter : --nth '.textcol.',.. --prompt "'.capname.'> " '.
   \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.
-  \            '--color hl:68,hl+:110'
+  \            '--color hl:68,hl+:110 --preview-window="'.preview_opts.'" --preview='.preview_cmd
   \}
   function! opts.sink(lines)
     return s:ag_handler(a:lines, self.column)

--- a/bin/ag_preview
+++ b/bin/ag_preview
@@ -8,11 +8,7 @@ help() {
 Usage: $0 [OPTIONS] FILE LINE
 Display the part of FILE for the LINE.
 
-  -C [LINES]  print lines before and after the LINE, default 5
-  -H [FORMAT] highlight the LINE_NO with following FORMAT:
-                UNDERLINE, BOLD, BLINK, REVERSE
-              default REVERSE
-
+  -b [LINES]  print lines before the LINE, default 5
   -h          show help
 EOF
 }
@@ -20,8 +16,7 @@ EOF
 
 file=
 line=
-context=5
-format=
+before=5
 
 # parse options
 argus="$(getopt C:H:h $*)"
@@ -29,11 +24,8 @@ set -- ${argus}
 
 while true; do
   case "$1" in
-    -C)
+    -b)
       shift; context=$1
-      ;;
-    -H)
-      shift; format=$1
       ;;
     -h)
       help; exit
@@ -49,38 +41,25 @@ done
 file=$1
 line=$2
 
-# setup the range
-max_line="$(( line + context ))"
-min_line="$(( line - context ))"
+# setup min line
+min_line="$(( line - before ))"
+[[ "${min_line}" -lt 1 ]] && min_line=1
 
-# setup highlight format
-case "${format}" in
-  UNDERLINE)
-    format="\033[4m"
-    ;;
-  BOLD)
-    format="\033[1m"
-    ;;
-  BLINK)
-    format="\033[5m"
-    ;;
-  REVERSE)
-    format="\033[7m"
-    ;;
-  *) # default is reverse
-    format="\033[7m"
-    ;;
-esac
+# TODO: max_line should be setup with the size of window
+#
+# For now, the preview window of fzf is not interactive terminal. We don't
+# know what is size of preview window extactly. In order to fill whole
+# window with text, set max_line here.
+# However, we cannot `cat` whole file, like log file, because there is
+# performance issue.
+max_line="$(( line + 500 ))"
 
 # output
 cat -n "${file}" \
   | awk -v line="${line}" \
-        -v maxl="${max_line}" \
         -v minl="${min_line}" \
-        -v fmt="${format}" \
-        ' {
-            if (NR <= maxl && NR >= minl) {
-              if (NR == line) { printf fmt; }
+        -v maxl="${max_line}" \
+        ' NR == minl, NR == maxl {
+              if (NR == line) { printf "\033[7m"; }
               print; printf "\033[0m"
-            }
           }'

--- a/bin/ag_preview
+++ b/bin/ag_preview
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# bash strict mode
+set -euo pipefail
+
+help() {
+  cat << EOF
+Usage: $0 [OPTIONS] FILE LINE
+Display the part of FILE for the LINE.
+
+  -C, --context [LINES]     print lines before and after the LINE, default 5
+  -H, --highlight [FORMAT]  highlight the LINE_NO with following FORMAT:
+                              UNDERLINE, BOLD, BLINK, REVERSE
+                            default REVERSE
+
+  -h, --help                show help
+EOF
+}
+
+
+file=
+line=
+context=5
+format=
+
+# parse options
+argus="$(getopt -u -o C:H:h -l context:,highlight:,help -- $*)"
+set -- ${argus}
+
+while true; do
+  case "$1" in
+    -C|--context)
+      shift; context=$1
+      ;;
+    -H|--highlight)
+      shift; format=$1
+      ;;
+    -h|--help)
+      help; exit
+      ;;
+    --)
+      shift; break
+      ;;
+  esac
+  shift
+done
+
+# setup FILE and LINE
+file=$1
+line=$2
+
+# setup the range
+max_line="$(( line + context ))"
+min_line="$(( line - context ))"
+
+# setup highlight format
+case "${format}" in
+  UNDERLINE)
+    format="\033[4m"
+    ;;
+  BOLD)
+    format="\033[1m"
+    ;;
+  BLINK)
+    format="\033[5m"
+    ;;
+  REVERSE)
+    format="\033[7m"
+    ;;
+  *) # default is reverse
+    format="\033[7m"
+    ;;
+esac
+
+# output
+cat -n "${file}" \
+  | awk -v line="${line}" \
+        -v maxl="${max_line}" \
+        -v minl="${min_line}" \
+        -v fmt="${format}" \
+        ' {
+            if (NR <= maxl && NR >= minl) {
+              if (NR == line) { printf fmt; }
+              print; printf "\033[0m"
+            }
+          }'

--- a/bin/ag_preview
+++ b/bin/ag_preview
@@ -8,12 +8,12 @@ help() {
 Usage: $0 [OPTIONS] FILE LINE
 Display the part of FILE for the LINE.
 
-  -C, --context [LINES]     print lines before and after the LINE, default 5
-  -H, --highlight [FORMAT]  highlight the LINE_NO with following FORMAT:
-                              UNDERLINE, BOLD, BLINK, REVERSE
-                            default REVERSE
+  -C [LINES]  print lines before and after the LINE, default 5
+  -H [FORMAT] highlight the LINE_NO with following FORMAT:
+                UNDERLINE, BOLD, BLINK, REVERSE
+              default REVERSE
 
-  -h, --help                show help
+  -h          show help
 EOF
 }
 
@@ -24,18 +24,18 @@ context=5
 format=
 
 # parse options
-argus="$(getopt -u -o C:H:h -l context:,highlight:,help -- $*)"
+argus="$(getopt C:H:h $*)"
 set -- ${argus}
 
 while true; do
   case "$1" in
-    -C|--context)
+    -C)
       shift; context=$1
       ;;
-    -H|--highlight)
+    -H)
       shift; format=$1
       ;;
-    -h|--help)
+    -h)
       help; exit
       ;;
     --)


### PR DESCRIPTION
By default, ':Ag something' only show the matched line for me.
If we can show the context of the matched line, it will help
us to make decision, like CTRL+SHIFT+F in sublime.

Therefore, I add preview window for Ag command.

<img width="1435" alt="screen shot 2016-10-23 at 00 31 54" src="https://cloud.githubusercontent.com/assets/17510957/19621009/67005b88-98bb-11e6-8e9c-b9700bdd4a2f.png">
<img width="1436" alt="screen shot 2016-10-23 at 00 33 33" src="https://cloud.githubusercontent.com/assets/17510957/19621010/68c5bb8e-98bb-11e6-8bec-2a49bd3675c1.png">
