### PR TITLE
[Buffers] Force formatting buffers relative to current dir

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -478,7 +478,7 @@ endfunction
 
 function! s:format_buffer(b)
   let name = bufname(a:b)
-  let name = empty(name) ? '[No Name]' : name
+  let name = empty(name) ? '[No Name]' : fnamemodify(name, ":~:.")
   let flag = a:b == bufnr('')  ? s:blue('%', 'Conditional') :
           \ (a:b == bufnr('#') ? s:magenta('#', 'Special') : ' ')
   let modified = getbufvar(a:b, '&modified') ? s:red(' [+]', 'Exception') : ''


### PR DESCRIPTION
Some plugins sometimes mess up with buffer names and so they become absolute.
This makes searching for buffers with fzf harder. This commit fixes that by
formatting buffers relatively to the cwd so fzf always get relative buffer
names.