### PR TITLE
use absolute path for windows and buffers

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -507,6 +507,7 @@ function! s:sort_buffers(...)
 endfunction
 
 function! fzf#vim#buffers(...)
+  cd /
   let bufs = map(sort(s:buflisted(), 's:sort_buffers'), 's:format_buffer(v:val)')
   return s:fzf('buffers', {
   \ 'source':  reverse(bufs),
@@ -898,7 +899,7 @@ endfunction
 function! s:format_win(tab, win, buf)
   let modified = getbufvar(a:buf, '&modified')
   let name = bufname(a:buf)
-  let name = empty(name) ? '[No Name]' : name
+  let name = empty(name) ? '[No Name]' : fnamemodify(name, ":~:.")
   let active = tabpagewinnr(a:tab) == a:win
   return (active? s:blue('> ', 'Operator') : '  ') . name . (modified? s:red(' [+]', 'Exception') : '')
 endfunction
@@ -909,6 +910,7 @@ function! s:windows_sink(line)
 endfunction
 
 function! fzf#vim#windows(...)
+  cd /
   let lines = []
   for t in range(1, tabpagenr('$'))
     let buffers = tabpagebuflist(t)


### PR DESCRIPTION
Currently, displaying the list of windows/buffers will use the path for the current edited file as the base path for all other paths. The means the list of paths will differ based on the path of the current file. 

This PR simply makes sure we 'cd /' first and then replaces the $HOME part of the path by '~'