### PR TITLE
Allow restyling of the fzf[123] groups

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -81,13 +81,13 @@ if has('nvim') && get(g:, 'fzf_nvim_statusline', 1)
       doautocmd User FzfStatusLine
     else
       if $TERM !~ "256color"
-        highlight fzf1 ctermfg=1 ctermbg=8 guifg=#E12672 guibg=#565656
-        highlight fzf2 ctermfg=2 ctermbg=8 guifg=#BCDDBD guibg=#565656
-        highlight fzf3 ctermfg=7 ctermbg=8 guifg=#D9D9D9 guibg=#565656
+        highlight default fzf1 ctermfg=1 ctermbg=8 guifg=#E12672 guibg=#565656
+        highlight default fzf2 ctermfg=2 ctermbg=8 guifg=#BCDDBD guibg=#565656
+        highlight default fzf3 ctermfg=7 ctermbg=8 guifg=#D9D9D9 guibg=#565656
       else
-        highlight fzf1 ctermfg=161 ctermbg=238 guifg=#E12672 guibg=#565656
-        highlight fzf2 ctermfg=151 ctermbg=238 guifg=#BCDDBD guibg=#565656
-        highlight fzf3 ctermfg=252 ctermbg=238 guifg=#D9D9D9 guibg=#565656
+        highlight default fzf1 ctermfg=161 ctermbg=238 guifg=#E12672 guibg=#565656
+        highlight default fzf2 ctermfg=151 ctermbg=238 guifg=#BCDDBD guibg=#565656
+        highlight default fzf3 ctermfg=252 ctermbg=238 guifg=#D9D9D9 guibg=#565656
       endif
       setlocal statusline=%#fzf1#\ >\ %#fzf2#fz%#fzf3#f
     endif


### PR DESCRIPTION
Tiny change. Allows users to set the styling on the fzf1, fzf2, and fzf3 highlight groups.