### PR TITLE
[fzf#vim#colors] Remove duplicate colorschemes

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -358,7 +358,7 @@ endfunction
 " ------------------------------------------------------------------
 function! fzf#vim#colors(...)
   return s:fzf('colors', {
-  \ 'source':  uniq(sort(map(split(globpath(&rtp, "colors/*.vim"), "\n"),
+  \ 'source':  s:uniq(sort(map(split(globpath(&rtp, "colors/*.vim"), "\n"),
   \               "substitute(fnamemodify(v:val, ':t'), '\\..\\{-}$', '', '')"))),
   \ 'sink':    'colo',
   \ 'options': '+m --prompt="Colors> "'

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -358,8 +358,8 @@ endfunction
 " ------------------------------------------------------------------
 function! fzf#vim#colors(...)
   return s:fzf('colors', {
-  \ 'source':  s:uniq(sort(map(split(globpath(&rtp, "colors/*.vim"), "\n"),
-  \               "substitute(fnamemodify(v:val, ':t'), '\\..\\{-}$', '', '')"))),
+  \ 'source':  s:uniq(map(split(globpath(&rtp, "colors/*.vim"), "\n"),
+  \               "substitute(fnamemodify(v:val, ':t'), '\\..\\{-}$', '', '')")),
   \ 'sink':    'colo',
   \ 'options': '+m --prompt="Colors> "'
   \}, a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -358,8 +358,8 @@ endfunction
 " ------------------------------------------------------------------
 function! fzf#vim#colors(...)
   return s:fzf('colors', {
-  \ 'source':  map(split(globpath(&rtp, "colors/*.vim"), "\n"),
-  \               "substitute(fnamemodify(v:val, ':t'), '\\..\\{-}$', '', '')"),
+  \ 'source':  uniq(sort(map(split(globpath(&rtp, "colors/*.vim"), "\n"),
+  \               "substitute(fnamemodify(v:val, ':t'), '\\..\\{-}$', '', '')"))),
   \ 'sink':    'colo',
   \ 'options': '+m --prompt="Colors> "'
   \}, a:000)


### PR DESCRIPTION
This makes it work more intuitively with plugins like [flazz/vim-colorschemes](https://github.com/flazz/vim-colorschemes).