### PR TITLE
fix :Tags by adding -a option to grep

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -766,7 +766,7 @@ function! fzf#vim#tags(query, ...)
   " We don't want to apply --ansi option when tags file is large as it makes
   " processing much slower.
   if getfsize(tagfile) > 1024 * 1024 * 20
-    let proc = 'grep -v ''^\!'' '
+    let proc = 'grep -av ''^\!'' '
     let copt = ''
   else
     let proc = 'perl -ne ''unless (/^\!/) { s/^(.*?)\t(.*?)\t/'.s:yellow('\1', 'Function').'\t'.s:blue('\2', 'String').'\t/; print }'' '


### PR DESCRIPTION
Somehow the tags file generated by ctags for the linux kernel, tag
v4.10-rc1 contains non-ASCII characters. grep stops when it detects
non-ASCII characters. This patch adds the -a option to the grep command
to treat the tags file as ASCII text.

Steps to reproduce:
```
$ git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
$ cd linux
$ git checkout v4.10-rc1
$ make O=. SRCARCH=x86 tags
$ grep -v '^!' tags | tail
Binary file tags matches
```

Another possibility is to call grep with `LC_ALL=C`.

(Fixes #5)