### PR TITLE
when checking exists of commands it checks full match

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -34,7 +34,7 @@ function! s:defs(commands)
   endif
   for command in a:commands
     let name = ':'.prefix.matchstr(command, '\C[A-Z]\S\+')
-    if !exists(name)
+    if 2 != exists(name)
       execute substitute(command, '\ze\C[A-Z]', prefix, '')
     endif
   endfor


### PR DESCRIPTION
if i defined commands start with `Ag`. (e.g. [1]) fzf.vim can't define `:Ag` command.
[1]: `command! AgGem call fzf#vim#ag(<q-args>)`