### PR TITLE
Support Windows (requires 0.16.10)

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1221,7 +1221,22 @@ endfunction
 
 function! s:complete_trigger()
   let opts = copy(s:opts)
-  let opts.options = printf('+m -q %s %s', shellescape(s:query), get(opts, 'options', ''))
+  let options = ['+m', '-q', s:query]
+  if has_key(opts, 'options')
+    if type(opts.options) == s:TYPE.list
+      let opts.options = options + opts.options
+    else
+      let shellslash = &shellslash
+      if s:is_win
+        set noshellslash
+      endif
+      let options[-1] = shellescape(s:query)
+      let &shellslash = shellslash
+      let opts.options = join(options).' '.opts.options
+    endif
+  else
+    let opts.options = options
+  endif
   let opts['sink*'] = s:function('s:complete_insert')
   let s:reducer = s:pluck(opts, 'reducer', s:function('s:first_line'))
   call fzf#run(opts)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -489,10 +489,12 @@ function! fzf#vim#gitfiles(args, ...)
   " Here be dragons!
   " We're trying to access the common sink function that fzf#wrap injects to
   " the options dictionary.
+  let script = tempname()
+  call writefile(['git diff --color=always -- {-1} | sed 1,4d; cat {-1}) | head -500'], script)
   let wrapped = fzf#wrap({
   \ 'source':  'git -c color.status=always status --short --untracked-files=all',
   \ 'dir':     root,
-  \ 'options': '--ansi --multi --nth 2..,.. --tiebreak=index --prompt "GitFiles?> " --preview ''sh -c "(git diff --color=always -- {-1} | sed 1,4d; cat {-1}) | head -500"'''
+  \ 'options': '--ansi --multi --nth 2..,.. --tiebreak=index --prompt "GitFiles?> " --preview "sh '.script.'"'
   \})
   call s:remove_layout(wrapped)
   let wrapped.common_sink = remove(wrapped, 'sink*')

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -678,9 +678,9 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   let opts = {
   \ 'source':  a:grep_command,
   \ 'column':  a:with_column,
-  \ 'options': '--ansi --delimiter : --nth '.textcol.',.. --prompt "'.capname.'> " '.
-  \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.
-  \            '--color hl:68,hl+:110'
+  \ 'options': ['--ansi', '--delimiter', ':', '--nth', textcol.',..', '--prompt', capname.'> ',
+  \            '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
+  \            '--color', 'hl:68,hl+:110']
   \}
   function! opts.sink(lines)
     return s:ag_handler(a:lines, self.column)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -734,10 +734,6 @@ function! s:btags_sink(lines)
   normal! zz
 endfunction
 
-function! s:q(query)
-  return ' --query '.shellescape(a:query)
-endfunction
-
 " query, [[tag commands], options]
 function! fzf#vim#buffer_tags(query, ...)
   let args = copy(a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -736,9 +736,23 @@ endfunction
 " query, [[tag commands], options]
 function! fzf#vim#buffer_tags(query, ...)
   let args = copy(a:000)
-  let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s 2>/dev/null', &filetype, expand('%:S')),
-    \ printf('ctags -f - --sort=no --excmd=number %s 2>/dev/null', expand('%:S'))]
+  if len(args) > 1 && type(args[0]) != s:TYPE.dict
+    let tag_cmds = remove(args, 0)
+  else
+    let null = s:is_win ? 'nul' : '/dev/null'
+    let shellslash = &shellslash
+    if s:is_win
+      set shellslash
+    endif
+    let file = expand('%')
+    if s:is_win
+      set noshellslash
+    endif
+    let tag_cmds = [
+    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s 2> '.null, &filetype, shellescape(file)),
+    \ printf('ctags -f - --sort=no --excmd=number %s 2> '.null, shellescape(file))]
+    let &shellslash = shellslash
+  endif
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]
   endif
@@ -746,7 +760,7 @@ function! fzf#vim#buffer_tags(query, ...)
     return s:fzf('btags', {
     \ 'source':  s:btags_source(tag_cmds),
     \ 'sink*':   s:function('s:btags_sink'),
-    \ 'options': '--reverse -m -d "\t" --with-nth 1,4.. -n 1 --prompt "BTags> "'.s:q(a:query)}, args)
+    \ 'options': ['--reverse', '-m', '-d', "\t", '--with-nth', '1,4..', '-n', '1','--prompt', 'BTags>', '--query', a:query]}, args)
   catch
     return s:warn(v:exception)
   endtry

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -994,13 +994,17 @@ function! fzf#vim#helptags(...)
   call map(tags, 'shellescape(v:val)')
   let sh_script = tempname()
   let perl_script = tempname()
-  let &shellslash = shellslash
   let path_regex = s:is_win ? '^[A-Z]:\/.*?[^:]' : '.*?'
   call writefile(['/('.path_regex.'):(.*?)\t(.*?)\t/; printf(qq('.s:green('%-40s', 'Label').
     \ '\t%s\t%s\n), $2, $3, $1)'], perl_script)
-  call writefile(['grep -H ''.*'' '.join(tags).' | perl -n '.perl_script.' | sort'], sh_script)
+  call writefile(['grep -H ''.*'' '.join(tags).' | perl -n '.shellescape(perl_script).' | sort'], sh_script)
+  if s:is_win
+    set noshellslash
+  endif
+  let source = 'sh '.shellescape(sh_script)
+  let &shellslash = shellslash
   return s:fzf('helptags', {
-  \ 'source':  'sh '.sh_script,
+  \ 'source':  source,
   \ 'sink':    s:function('s:helptag_sink'),
   \ 'options': '--ansi +m --tiebreak=begin --with-nth ..-2'}, a:000)
 endfunction

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -639,9 +639,16 @@ function! fzf#vim#ag(query, ...)
     return s:warn('Invalid query argument')
   endif
   let query = empty(a:query) ? '^(?=.)' : a:query
+  if s:is_win && &shellslash
+    set noshellslash
+    let query = shellescape(query)
+    set shellslash
+  else
+    let query = shellescape(query)
+  endif
   let args = copy(a:000)
   let ag_opts = len(args) > 1 && type(args[0]) == s:TYPE.string ? remove(args, 0) : ''
-  let command = ag_opts . ' ' . shellescape(query)
+  let command = ag_opts . ' ' . query
   return call('fzf#vim#ag_raw', insert(args, command, 0))
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -334,10 +334,14 @@ function! fzf#vim#lines(...)
   let nth = display_bufnames ? 3 : 2
   let [query, args] = (a:0 && type(a:1) == type('')) ?
         \ [a:1, a:000[1:]] : ['', a:000]
+  let opts = ['+m', '--tiebreak=index', '--prompt', 'Lines> ', '--ansi', '--extended', '--nth='.nth.'..', '--reverse', '--tabstop=1']
+  if len(query)
+    call extend(opts, ['--query', query])
+  endif
   return s:fzf('lines', {
   \ 'source':  lines,
   \ 'sink*':   s:function('s:line_handler'),
-  \ 'options': '+m --tiebreak=index --prompt "Lines> " --ansi --extended --nth='.nth.'.. --reverse --tabstop=1'.s:q(query)
+  \ 'options': opts
   \}, args)
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -396,12 +396,18 @@ endfunction
 " ------------------------------------------------------------------
 " Locate
 " ------------------------------------------------------------------
-function! fzf#vim#locate(query, ...)
-  return s:fzf('locate', {
-  \ 'source':  'locate '.a:query,
-  \ 'options': '-m --prompt "Locate> "'
-  \}, a:000)
-endfunction
+if s:is_win
+  function! fzf#vim#locate(query, ...)
+    return s:warn('Not supported in Windows')
+  endfunction
+else
+  function! fzf#vim#locate(query, ...)
+    return s:fzf('locate', {
+    \ 'source':  'locate '.a:query,
+    \ 'options': '-m --prompt "Locate> "'
+    \}, a:000)
+  endfunction
+endif
 
 " ------------------------------------------------------------------
 " History[:/]

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -273,6 +273,7 @@ function! fzf#vim#files(dir, ...)
   elseif len(opts)
     call add(args.options, opts)
   endif
+
   return s:fzf('files', args, a:000)
 endfunction
 
@@ -991,6 +992,7 @@ function! fzf#vim#helptags(...)
   endif
   let sorted = sort(split(globpath(&runtimepath, 'doc/tags'), '\n'))
   let tags = exists('*uniq') ? uniq(sorted) : fzf#vim#_uniq(sorted)
+
   call map(tags, 'shellescape(v:val)')
   let sh_script = tempname()
   let perl_script = tempname()
@@ -1102,6 +1104,7 @@ function! s:commits(buffer_local, args)
     call system('git show '.shellescape(current).' 2> '.(s:is_win ? 'nul' : '/dev/null'))
     let managed = !v:shell_error
   endif
+
   if a:buffer_local
     if !managed
       let &shellslash = shellslash
@@ -1112,6 +1115,7 @@ function! s:commits(buffer_local, args)
     endif
     let source .= ' --follow '.shellescape(current)
   endif
+
   if s:is_win
     set shellslash
     let shellscript = tempname()

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -941,12 +941,22 @@ function! s:helptag_sink(line)
 endfunction
 
 function! fzf#vim#helptags(...)
+  let shellslash = &shellslash
+  if s:is_win
+    set shellslash
+  endif
   let sorted = sort(split(globpath(&runtimepath, 'doc/tags'), '\n'))
   let tags = exists('*uniq') ? uniq(sorted) : fzf#vim#_uniq(sorted)
-
+  call map(tags, 'shellescape(v:val)')
+  let sh_script = tempname()
+  let perl_script = tempname()
+  let &shellslash = shellslash
+  let path_regex = s:is_win ? '^[A-Z]:\/.*?[^:]' : '.*?'
+  call writefile(['/('.path_regex.'):(.*?)\t(.*?)\t/; printf(qq('.s:green('%-40s', 'Label').
+    \ '\t%s\t%s\n), $2, $3, $1)'], perl_script)
+  call writefile(['grep -H ''.*'' '.join(tags).' | perl -n '.perl_script.' | sort'], sh_script)
   return s:fzf('helptags', {
-  \ 'source':  "grep -H '.*' ".join(map(tags, 'shellescape(v:val)')).
-    \ "| perl -ne '/(.*?):(.*?)\t(.*?)\t/; printf(qq(".s:green('%-40s', 'Label')."\t%s\t%s\n), $2, $3, $1)' | sort",
+  \ 'source':  'sh '.sh_script,
   \ 'sink':    s:function('s:helptag_sink'),
   \ 'options': '--ansi +m --tiebreak=begin --with-nth ..-2'}, a:000)
 endfunction

--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -25,6 +25,13 @@ let s:cpo_save = &cpo
 set cpo&vim
 let s:is_win = has('win32') || has('win64')
 
+function! s:warn(message)
+  echohl WarningMsg
+  echom a:message
+  echohl None
+  return 0
+endfunction
+
 function! s:extend(base, extra)
   let base = copy(a:base)
   if has_key(a:extra, 'options')
@@ -46,11 +53,18 @@ else
   endfunction
 endif
 
-function! fzf#vim#complete#word(...)
-  return fzf#vim#complete(s:extend({
-    \ 'source': 'cat /usr/share/dict/words'},
-    \ get(a:000, 0, fzf#wrap())))
-endfunction
+if s:is_win
+  function! fzf#vim#complete#word(...)
+    call s:warn('Not supported in Windows')
+    return ''
+  endfunction
+else
+  function! fzf#vim#complete#word(...)
+    return fzf#vim#complete(s:extend({
+          \ 'source': 'cat /usr/share/dict/words'},
+          \ get(a:000, 0, fzf#wrap())))
+  endfunction
+endif
 
 " ----------------------------------------------------------------------------
 " <plug>(fzf-complete-path)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -23,6 +23,7 @@
 
 let s:cpo_save = &cpo
 set cpo&vim
+let s:is_win = has('win32') || has('win64')
 
 function! s:defs(commands)
   let prefix = get(g:, 'fzf_command_prefix', '')
@@ -122,10 +123,16 @@ augroup fzf_buffers
   autocmd BufDelete * silent! call remove(g:fzf#vim#buffers, expand('<abuf>'))
 augroup END
 
+if s:is_win
+  inoremap <expr> <plug>(fzf-complete-path)     fzf#vim#complete#path('dir /s/b')
+  inoremap <expr> <plug>(fzf-complete-file)     fzf#vim#complete#path('dir /s/b/a:-d')
+else
+  inoremap <expr> <plug>(fzf-complete-path)     fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
+  inoremap <expr> <plug>(fzf-complete-file)     fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
+endif
+
 inoremap <expr> <plug>(fzf-complete-word)        fzf#vim#complete#word()
-inoremap <expr> <plug>(fzf-complete-path)        fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
-inoremap <expr> <plug>(fzf-complete-file)        fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
-inoremap <expr> <plug>(fzf-complete-file-ag)     fzf#vim#complete#path("ag -l -g ''")
+inoremap <expr> <plug>(fzf-complete-file-ag)     fzf#vim#complete#path('ag -l -g ""')
 inoremap <expr> <plug>(fzf-complete-line)        fzf#vim#complete#line()
 inoremap <expr> <plug>(fzf-complete-buffer-line) fzf#vim#complete#buffer_line()
 


### PR DESCRIPTION
Main PR to fix commands for Windows and use list type for options if required.
Added workarounds for commands not using list type for options such as `:Helptags`

`fzf#shellescape` is not used in this PR so `shellslash` is set/unset depending on the function.
- `set shellslash`
  - path functions such as `expand` and `glob` to avoid `\"`
  - `shellescape` commands on sh
- `set noshellslash`
  - `shellescape` commands on cmd.exe

**Requirements**
-  fzf [0.16.10](https://github.com/junegunn/fzf-bin/releases/tag/0.16.10) or later versions so commands generating relative filepaths will work in both vim/neovim (junegunn/fzf#969 and junegunn/fzf#970)
- Cygwin utilities (sh, grep, perl, etc.) available in `PATH` to reduce maintenance burden
- Windows 7 or later versions
- Vim 7.4+ or Neovim 0.2+

**Functions**
- [ ] `s:fzf` (48ad1c3, supports list type for options)
- [ ] `s:wrap` (48ad1c3, supports list type for options)
- [X] `fzf#vim#grep` (9a72951)
  - requires list type for option if prompt contains quotes or escape characters (`\^"`)
- [ ] `fzf#vim#complete`
  - [X] `s:complete_trigger` (da8f862)
  - [ ] `fzf#vim#complete#word` (f1619d4, not supported)
    - relies on `/usr/share/dict/words` which does not exist in Windows (no equivalent??)
  - [ ] `fzf#vim#complete#path` (24c6594)
    - requires `set shellslash` for now
    - TODO: use list type for options to resolve shellescape issues in cmd.exe
  - [ ] `fzf#vim#complete#line`
  - [ ] `fzf#vim#complete#buffer_line`
- [X] `fzf#vim#map` (no fixes required)
- [X] `fzf#vim#with_preview` (9535460)

**Commands**
- [X] `Files` (48ad1c3)
- [x] `GFiles` (no fixes required)
- [x] `GFiles?` (7e5a6af, list type for options not required, requires sh.exe from Cygwin)
- [X] `Buffers` (48ad1c3)
- [x] `Colors` (no fixes required)
- [x] `Ag` (a943f21)
  - depends on `fzf#vim#grep`
- [X] `Lines` (cb86ba6)
- [X] `BLines` (48ad1c3)
- [X] `Tags` (7ed4abb)
- [X] `BTags` (7cfbeca)
- [X] `Marks` (no fixes required)
- [X] `Windows` (no fixes required)
- [ ] `Locate` (052ec67, not supported)
  - `locate` requires Cygwin and is useless without indexing in Windows 7/8
  - no built-in alternative in Windows 7/8
  - need some check to enable the command for WSL users
- [X] `History` (no fixes required)
- [X] `History:` (no fixes required)
- [X] `History/` (no fixes required)
- [X] `Snippets` (no fixes required)
- [X] `Commits` (6d49ed1, requires sh.exe from Cygwin)
  - [X] `Bcommits` (6d49ed1)
- [x] `Commands`
- [X] `Maps` (no fixes required)
- [X] `Helptags` (https://github.com/junegunn/fzf.vim/issues/376)
  - [X] Resolve command for source (6858b23, 03c85fd)
     - uses sh, grep, perl, sort (requires Cygwin)
     - ~~initial run takes about 1 minute (vimscript bottleneck?)~~ resolved with 990834a
- [x] `Filetypes` (no fixes required)

**Mappings**
- [ ] `<plug>(fzf-complete-word)` (f1619d4, not supported)
- [ ] `<plug>(fzf-complete-path)` (24c6594)
  - outputs absolute path in Windows
- [ ] `<plug>(fzf-complete-file)` (24c6594)
  - outputs absolute path in Windows
- [ ] `<plug>(fzf-complete-file-ag)` (24c6594)
- [ ] `<plug>(fzf-complete-line)`
- [ ] `<plug>(fzf-complete-buffer-line)`

- [X] `<plug>(fzf-maps-n)` (no fixes required)
- [X] `<plug>(fzf-maps-i)` (no fixes required)
- [X] `<plug>(fzf-maps-x)` (no fixes required)
- [X] `<plug>(fzf-maps-o)` (no fixes required)