### PR TITLE
Add HgFiles command to run fzf on Mercurial repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Commands
 | `Files [PATH]`    | Files (similar to `:FZF`)                                               |
 | `GFiles [OPTS]`   | Git files (`git ls-files`)                                              |
 | `GFiles?`         | Git files (`git status`)                                                |
+| `HgFiles [OPTS]`  | Hg files                                                                |
 | `Buffers`         | Open buffers                                                            |
 | `Colors`          | Color schemes                                                           |
 | `Ag [PATTERN]`    | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all) |

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -491,6 +491,35 @@ function! fzf#vim#gitfiles(args, ...)
 endfunction
 
 " ------------------------------------------------------------------
+" HgFiles
+" ------------------------------------------------------------------
+
+" helper function to get the hg root. Uses lawrencium if available.
+function! s:get_hg_root()
+  if exists('*lawrencium#find_repo_root')
+    try
+      " find_repo_root adds a trailing slash.
+      return lawrencium#stripslash(lawrencium#find_repo_root(getcwd()))
+    catch
+    endtry
+  endif
+  let root = split(system('hg root'), '\n')[0]
+  return v:shell_error ? '' : root
+endfunction
+
+function! fzf#vim#hgfiles(args, ...)
+  let root = s:get_hg_root()
+  if empty(root)
+    return s:warn('Not in hg repo')
+  endif
+  return s:fzf('hgfiles', {
+  \ 'source':  'hg status --no-status --modified --added --clean --unknown '.a:args,
+  \ 'dir':     root,
+  \ 'options': '-m --prompt "HgFiles> "'
+  \}, a:000)
+endfunction
+
+" ------------------------------------------------------------------
 " Buffers
 " ------------------------------------------------------------------
 function! s:find_open_window(b)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -77,6 +77,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `Files [PATH]`    | Files (similar to  `:FZF` )
   `GFiles [OPTS]`   | Git files (git ls-files)
   `GFiles?`         | Git files (git status)
+  `HgFiles [OPTS]`  | Hg files
   `Buffers`         | Open buffers
   `Colors`          | Color schemes
   `Ag [PATTERN]`    | {ag}{5} search result (ALT-A to select all, ALT-D to deselect all)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -44,6 +44,7 @@ call s:defs([
 \'command!      -bang -nargs=? -complete=dir Files       call fzf#vim#files(<q-args>, <bang>0)',
 \'command!      -bang -nargs=? GitFiles                  call fzf#vim#gitfiles(<q-args>, <bang>0)',
 \'command!      -bang -nargs=? GFiles                    call fzf#vim#gitfiles(<q-args>, <bang>0)',
+\'command!      -bang -nargs=? HgFiles                   call fzf#vim#hgfiles(<q-args>, <bang>0)',
 \'command! -bar -bang -nargs=? -complete=buffer Buffers  call fzf#vim#buffers(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* Lines                     call fzf#vim#lines(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BLines                    call fzf#vim#buffer_lines(<q-args>, <bang>0)',


### PR DESCRIPTION
This uses `hg status` along with the relevant flags to only display existing, non-hgignore'd files (and new, unknown files).