### PR TITLE
Added all default `fzf_action`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ pathogen#helptags()`. [↩](#a1))
 ```vim
 " This is the default extra key bindings
 let g:fzf_action = {
+  \ '': '', " the default (enter) action
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
   \ 'ctrl-v': 'vsplit' }


### PR DESCRIPTION
The current documentation doesn't mention the 4th default fzf_action, opening in the current buffer for a simple <kbd>enter</kbd>