### PR TITLE
[Files] runs in Windows

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -55,9 +55,6 @@ endfunction
 function! fzf#vim#with_preview(...)
   " Default options
   let options = {}
-  if s:is_win
-    return options
-  endif
   let window = 'right'
 
   let args = copy(a:000)
@@ -66,6 +63,9 @@ function! fzf#vim#with_preview(...)
   if len(args) && type(args[0]) == s:TYPE.dict
     let options = copy(args[0])
     call remove(args, 0)
+  endif
+  if s:is_win
+    return options
   endif
 
   " Preview window

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -55,6 +55,9 @@ endfunction
 function! fzf#vim#with_preview(...)
   " Default options
   let options = {}
+  if s:is_win
+    return options
+  endif
   let window = 'right'
 
   let args = copy(a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -29,27 +29,6 @@ set cpo&vim
 " ------------------------------------------------------------------
 
 let s:is_win = has('win32') || has('win64')
-if s:is_win
-  function! s:fzf_call(fn, ...)
-    let shellslash = &shellslash
-    try
-      set noshellslash
-      return call(a:fn, a:000)
-    finally
-      let &shellslash = shellslash
-    endtry
-  endfunction
-else
-  function! s:fzf_call(fn, ...)
-    return call(a:fn, a:000)
-  endfunction
-endif
-
-function! s:fzf_shellescape(str)
-  let escaped =  s:fzf_call('shellescape', a:str)
-  return s:is_win ? substitute(escaped, '[^\\]\zs\\$', '\\\\', '') : escaped
-endfunction
-
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
 let s:bin = {
@@ -65,7 +44,7 @@ function! s:merge_opts(dict, eopts)
   if type(opts) == s:TYPE.list && type(a:eopts) == s:TYPE.list
     call extend(a:dict.options, eopts)
   else
-    let a:dict.options = join(map([opts, a:eopts], 'type(v:val) == s:TYPE.list ? join(map(v:val, "s:fzf_shellescape(v:val)")) : v:val'))
+    let a:dict.options = join(map([opts, a:eopts], 'type(v:val) == s:TYPE.list ? join(map(copy(v:val), "fzf#shellescape(v:val)")) : v:val'))
   endif
 endfunction
 


### PR DESCRIPTION
Initial work for  #410.
I added `s:merge_opts` to handle `eopts` so it can fallback to string options.
I didn't use `fzf#shellescape` so it work in Window only if `g:fzf_files_options` is unset or a list.

Maybe it's better to not support string values for these user options in Windows.