### PR TITLE
exclude the current file from History

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -464,7 +464,7 @@ endfunction
 
 function! fzf#vim#history(...)
   return s:fzf('history-files', {
-  \ 'source':  reverse(s:all_files()),
+  \ 'source':  filter(reverse(s:all_files()), 'v:val != expand("%")'),
   \ 'options': '-m --prompt "Hist> "'
   \}, a:000)
 endfunction


### PR DESCRIPTION
This is the first time I've ever written VimL, so I'm sure there's a better way to do it. But this seems to achieve what we were looking for in https://github.com/junegunn/fzf.vim/issues/367 :) @junegunn do you think excluding the current file would be a good idea in general?