### PR TITLE
[Lines,BLines,Buffers] works in Windows

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -711,7 +711,7 @@ function! s:btags_sink(lines)
 endfunction
 
 function! s:q(query)
-  return ' --query '.shellescape(a:query)
+  return ' --query '.fzf#shellescape(a:query)
 endfunction
 
 " query, [[tag commands], options]


### PR DESCRIPTION
Need https://github.com/junegunn/fzf/pull/1021 for the backslash queries
`s:q` uses `fzf#shellescape` now but `Tags` and `BTags` use `s:q`.

What do you think of removing/reworking `s:q` and use list type for options?
