### PR TITLE
[Tags] support Windows-style absolute filepaths

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -753,8 +753,8 @@ function! s:tags_sink(lines)
         let excmd   = matchstr(join(parts[2:-2], '')[:-2], '^.*\ze;"\t')
         let base    = fnamemodify(parts[-1], ':h')
         let relpath = parts[1][:-2]
-        let abspath = relpath =~ '^/' ? relpath : join([base, relpath], '/')
-        call s:open(cmd, abspath)
+        let abspath = relpath =~ (s:is_win ? '^[A-Z]:\' : '^/') ? relpath : join([base, relpath], '/')
+        call s:open(cmd, expand(abspath, 1))
         execute excmd
         call add(qfl, {'filename': expand('%'), 'lnum': line('.'), 'text': getline('.')})
       catch /^Vim:Interrupt$/


### PR DESCRIPTION
Resolves https://github.com/junegunn/fzf.vim/pull/427#issuecomment-323584383

Supports the absolute filepaths generated by `ctags -R --output-format=e-ctags --tag-relative=never`