### PR TITLE
[Ag, fzf#vim#grep] works in Windows

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -205,7 +205,8 @@ function! s:fzf(name, opts, extra)
   let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
   let merged = extend(copy(a:opts), extra)
   call s:merge_opts(merged, eopts)
-  if s:is_win && empty(get(merged, 'source', '')) && empty($FZF_DEFAULT_COMMAND) && get(merged, 'options', '') =~# s:bin.preview
+  let mopts = get(merged, 'options', '')
+  if s:is_win && empty(get(merged, 'source', '')) && empty($FZF_DEFAULT_COMMAND) && (type(mopts) == s:TYPE.list ? join(mopts) : mopts) =~# s:bin.preview
     return s:warn('preview script is incompatible with the default command in Windows')
   endif
   return fzf#run(s:wrap(a:name, merged, bang))

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -35,6 +35,15 @@ let s:bin = {
 \ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
+if s:is_win
+  if &shellslash
+    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
+  else
+    set shellslash
+    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
+    set noshellslash
+  endif
+endif
 
 function! s:merge_opts(dict, eopts)
   if empty(a:eopts)
@@ -74,17 +83,7 @@ function! fzf#vim#with_preview(...)
     call remove(args, 0)
   endif
 
-  if s:is_win
-    if exists('s:preview_script')
-      silent! call delete(s:preview_script)
-    endif
-    let s:preview_script = tempname().'.bat'
-    call writefile(['@echo off', fzf#shellescape(s:bin.preview).' %*'], s:preview_script)
-    let script = s:preview_script
-  else
-    let script = s:bin.preview
-  endif
-  let preview = ['--preview-window', window, '--preview', script.(window =~ 'up\|down' ? ' -v ' : ' ').'{}']
+  let preview = ['--preview-window', window, '--preview', s:bin.preview.' '.(window =~ 'up\|down' ? '-v' : '').' {}']
 
   if len(args)
     call extend(preview, ['--bind', join(map(args, 'v:val.":toggle-preview"'), ',')])

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -36,13 +36,12 @@ let s:bin = {
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 if s:is_win
-  if &shellslash
-    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
+  if has('nvim')
+    let s:bin.preview = split(system('for %A in ("'.s:bin.preview.'") do echo %~sA'), "\n")[1]
   else
-    set shellslash
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
-    set noshellslash
   endif
+  let s:bin.preview = escape(s:bin.preview, '\')
 endif
 
 function! s:merge_opts(dict, eopts)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -35,15 +35,6 @@ let s:bin = {
 \ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
-if s:is_win
-  if &shellslash
-    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
-  else
-    set shellslash
-    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
-    set noshellslash
-  endif
-endif
 
 function! s:merge_opts(dict, eopts)
   if empty(a:eopts)
@@ -83,7 +74,17 @@ function! fzf#vim#with_preview(...)
     call remove(args, 0)
   endif
 
-  let preview = ['--preview-window', window, '--preview', s:bin.preview.' '.(window =~ 'up\|down' ? '-v' : '').' {}']
+  if s:is_win
+    if exists('s:preview_script')
+      silent! call delete(s:preview_script)
+    endif
+    let s:preview_script = tempname().'.bat'
+    call writefile(['@echo off', fzf#shellescape(s:bin.preview).' %*'], s:preview_script)
+    let script = s:preview_script
+  else
+    let script = s:bin.preview
+  endif
+  let preview = ['--preview-window', window, '--preview', script.(window =~ 'up\|down' ? ' -v ' : ' ').'{}']
 
   if len(args)
     call extend(preview, ['--bind', join(map(args, 'v:val.":toggle-preview"'), ',')])

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -630,7 +630,7 @@ function! fzf#vim#ag(query, ...)
   let query = empty(a:query) ? '^(?=.)' : a:query
   let args = copy(a:000)
   let ag_opts = len(args) > 1 && type(args[0]) == s:TYPE.string ? remove(args, 0) : ''
-  let command = ag_opts . ' ' . shellescape(query)
+  let command = ag_opts . ' ' . fzf#shellescape(query)
   return call('fzf#vim#ag_raw', insert(args, command, 0))
 endfunction
 
@@ -654,9 +654,9 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   let opts = {
   \ 'source':  a:grep_command,
   \ 'column':  a:with_column,
-  \ 'options': '--ansi --prompt "'.capname.'> " '.
-  \            '--multi --bind alt-a:select-all,alt-d:deselect-all '.
-  \            '--color hl:68,hl+:110'
+  \ 'options': ['--ansi', '--prompt', capname.'> ',
+  \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
+  \             '--color', 'hl:68,hl+:110']
   \}
   function! opts.sink(lines)
     return s:ag_handler(a:lines, self.column)


### PR DESCRIPTION
It should work with the preview because ag does not output the network drive but the absolute filepath of the preview script must be modified with `fnamemodify` and  either `set shellslash` or `escape(abspath, '\')` to get around escaping issues.

Ideally, `s:fzf` should return early if running on windows, the preview script is used and if there is either no source or `FZF_DEFAULT_COMMAND` is undefined such that fzf defaults to `dir /s/b`.