### PR TITLE
[fzf#vim#complete#path] works in Windows

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1171,7 +1171,7 @@ endfunction
 
 function! s:complete_trigger()
   let opts = copy(s:opts)
-  let opts.options = printf('+m -q %s %s', shellescape(s:query), get(opts, 'options', ''))
+  call s:merge_opts(opts, ['+m', '-q', s:query])
   let opts['sink*'] = s:function('s:complete_insert')
   let s:reducer = s:pluck(opts, 'reducer', s:function('s:first_line'))
   call fzf#run(opts)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1255,9 +1255,10 @@ function! fzf#vim#complete(...)
     call s:merge_opts(s:opts, remove(s:opts, 'extra_options'))
   endif
   if has_key(s:opts, 'options')
-    " FIXME: fzf currently doesn't have --no-expect option
-    if type(s:opts.options) == s:TYPE.string
-      let s:opts.options = substitute(s:opts.options, '--expect=[^ ]*', '', 'g')
+    if type(s:opts.options) == s:TYPE.list
+      call add(s:opts.options, '--no-expect')
+    else
+      let s:opts.options .= ' --no-expect'
     endif
   endif
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1252,12 +1252,13 @@ function! fzf#vim#complete(...)
   let s:opts = s:eval(s:opts, 'options', s:query)
   let s:opts = s:eval(s:opts, 'extra_options', s:query)
   if has_key(s:opts, 'extra_options')
-    let s:opts.options =
-      \ join(filter([get(s:opts, 'options', ''), remove(s:opts, 'extra_options')], '!empty(v:val)'))
+    call s:merge_opts(s:opts, remove(s:opts, 'extra_options'))
   endif
   if has_key(s:opts, 'options')
     " FIXME: fzf currently doesn't have --no-expect option
-    let s:opts.options = substitute(s:opts.options, '--expect=[^ ]*', '', 'g')
+    if type(s:opts.options) == s:TYPE.string
+      let s:opts.options = substitute(s:opts.options, '--expect=[^ ]*', '', 'g')
+    endif
   endif
 
   call feedkeys("\<Plug>(-fzf-complete-trigger)")

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -23,6 +23,7 @@
 
 let s:cpo_save = &cpo
 set cpo&vim
+let s:is_win = has('win32') || has('win64')
 
 function! s:defs(commands)
   let prefix = get(g:, 'fzf_command_prefix', '')
@@ -123,9 +124,14 @@ augroup fzf_buffers
 augroup END
 
 inoremap <expr> <plug>(fzf-complete-word)        fzf#vim#complete#word()
-inoremap <expr> <plug>(fzf-complete-path)        fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
-inoremap <expr> <plug>(fzf-complete-file)        fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
-inoremap <expr> <plug>(fzf-complete-file-ag)     fzf#vim#complete#path("ag -l -g ''")
+if s:is_win
+  inoremap <expr> <plug>(fzf-complete-path)      fzf#vim#complete#path('dir /s/b')
+  inoremap <expr> <plug>(fzf-complete-file)      fzf#vim#complete#path('dir /s/b/a:-d')
+else
+  inoremap <expr> <plug>(fzf-complete-path)      fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
+  inoremap <expr> <plug>(fzf-complete-file)      fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
+endif
+inoremap <expr> <plug>(fzf-complete-file-ag)     fzf#vim#complete#path('ag -l -g ""')
 inoremap <expr> <plug>(fzf-complete-line)        fzf#vim#complete#line()
 inoremap <expr> <plug>(fzf-complete-buffer-line) fzf#vim#complete#buffer_line()
 


### PR DESCRIPTION
Aside from `<plug>(fzf-complete-word)`, all of the other `<plug>`  are okay.
I used double quotes for `<plug>(fzf-complete-file-ag)` because single quotes for empty pattern doesn't work for ag in cmd.exe

Tested only in Vim and GVim.
For some reason, mappings don't work anymore in Neovim on Windows.