### PR TITLE
[fzf#vim#preview] works with Windows default command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -32,7 +32,7 @@ let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
 let s:bin = {
-\ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
+\ 'preview': s:bin_dir.(!s:is_win && executable('ruby') ? 'preview.rb' : 'preview.sh'),
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 if s:is_win
@@ -41,7 +41,7 @@ if s:is_win
   else
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
   endif
-  let s:bin.preview = escape(s:bin.preview, '\')
+  let s:bin.preview = 'bash '.escape(s:bin.preview, '\')
 endif
 
 function! s:merge_opts(dict, eopts)
@@ -204,10 +204,6 @@ function! s:fzf(name, opts, extra)
   let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
   let merged = extend(copy(a:opts), extra)
   call s:merge_opts(merged, eopts)
-  let mopts = get(merged, 'options', '')
-  if s:is_win && empty(get(merged, 'source', '')) && empty($FZF_DEFAULT_COMMAND) && (type(mopts) == s:TYPE.list ? join(mopts) : mopts) =~# s:bin.preview
-    return s:warn('preview script is incompatible with the default command in Windows')
-  endif
   return fzf#run(s:wrap(a:name, merged, bang))
 endfunction
 

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -16,7 +16,7 @@ fi
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 
-if [[ $FILE =~ '^[A-Z]$' ]]; then
+if [[ $1 =~ ^[A-Z]:\\ ]]; then
   FILE=$FILE:${INPUT[1]}
   shift
 fi

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -15,6 +15,12 @@ fi
 
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
+
+if [[ $FILE =~ '^[A-Z]$' ]]; then
+  FILE=$FILE:${INPUT[1]}
+  shift
+fi
+
 CENTER=${INPUT[1]}
 
 if [ ! -r "$FILE" ]; then

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -15,13 +15,12 @@ fi
 
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
+CENTER=${INPUT[1]}
 
 if [[ $1 =~ ^[A-Z]:\\ ]]; then
   FILE=$FILE:${INPUT[1]}
-  shift
+  CENTER=${INPUT[2]}
 fi
-
-CENTER=${INPUT[1]}
 
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"


### PR DESCRIPTION
Ruby script doesn't work with cmd.exe in the terminal if the script is run in a batchfile.
I don't know how to preview the file in a batchfile or powershell so bash script is the only option. I adjusted the bash script to handle the network drive such that it works with `dir /s/b`.