### PR TITLE
Remove hardcoded highlighting color

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -683,8 +683,7 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   \ 'source':  a:grep_command,
   \ 'column':  a:with_column,
   \ 'options': ['--ansi', '--prompt', capname.'> ',
-  \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
-  \             '--color', 'hl:68,hl+:110']
+  \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all']
   \}
   function! opts.sink(lines)
     return s:ag_handler(a:lines, self.column)


### PR DESCRIPTION
This option overrides the custom color settings in `FZF_DEFAULT_OPTS`, which should not happen. If that is not set by the user, it should use the default value of fzf (this seems to be the wrong location to set such a default).

Closes #452