### PR TITLE
[fzf#vim#preview] Use ruby in Windows if available

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -32,7 +32,7 @@ let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
 let s:bin = {
-\ 'preview': s:bin_dir.(!s:is_win && executable('ruby') ? 'preview.rb' : 'preview.sh'),
+\ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 if s:is_win
@@ -41,7 +41,7 @@ if s:is_win
   else
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
   endif
-  let s:bin.preview = 'bash '.escape(s:bin.preview, '\')
+  let s:bin.preview = (executable('ruby') ? 'ruby' : 'bash').' '.escape(s:bin.preview, '\')
 endif
 
 function! s:extend_opts(dict, eopts, prepend)

--- a/bin/preview.rb
+++ b/bin/preview.rb
@@ -18,7 +18,11 @@ end
 
 usage if ARGV.empty?
 
-file, center = ARGV.first.split(':')
+file, center, extra = ARGV.first.split(':')
+if ARGV.first =~ /^[A-Z]:\\/
+  file << ':' + center
+  center = extra
+end
 usage unless file
 
 path = File.expand_path(file)


### PR DESCRIPTION
Close #459
Requires 0.17.1

This re-enables the ruby preview script if ruby is available in PATH. The changes is a port of the fix for Windows' network drive in the bash preview script.