### PR TITLE
Avoid duplicate entries in :GFiles

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -508,7 +508,7 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  'git ls-files '.a:args.' | uniq',
+    \ 'source':  'git ls-files '.a:args.(s:is_win ? '' : ' | uniq'),
     \ 'dir':     root,
     \ 'options': '-m --prompt "GitFiles> "'
     \}, a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -508,7 +508,7 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  'git ls-files '.a:args.' | sort | uniq',
+    \ 'source':  'git ls-files '.a:args.' | uniq',
     \ 'dir':     root,
     \ 'options': '-m --prompt "GitFiles> "'
     \}, a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -508,7 +508,7 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  'git ls-files '.a:args,
+    \ 'source':  'git ls-files '.a:args.' | sort | uniq',
     \ 'dir':     root,
     \ 'options': '-m --prompt "GitFiles> "'
     \}, a:000)


### PR DESCRIPTION
This should crudely filter out files that are listed multiple times in `git ls-files` because of the state they're in (e.g. during a rebase).

Perhaps there is a better way to achieve this? I'm afraid I'm not very familiar with the internals of `fzf` / `fzf.vim`.

Thanks,
Josh