### PR TITLE
Don't attempt to render disparate chunks of commit graph in :BCommits

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1070,7 +1070,7 @@ function! s:commits(buffer_local, args)
     return s:warn('Not in git repository')
   endif
 
-  let source = 'git log '.get(g:, 'fzf_commits_log_options', '--graph --color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
+  let source = 'git log '.get(g:, 'fzf_commits_log_options', '--color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
   let current = expand('%')
   let managed = 0
   if !empty(current)
@@ -1083,6 +1083,8 @@ function! s:commits(buffer_local, args)
       return s:warn('The current buffer is not in the working tree')
     endif
     let source .= ' --follow '.fzf#shellescape(current)
+  else
+    let source .= ' --graph'
   endif
 
   let command = a:buffer_local ? 'BCommits' : 'Commits'


### PR DESCRIPTION
This PR removes the `--graph` flag when only listing commits for the current buffer.

Given that the list of commits for the given buffer are not generally contiguous in the git tree, the graph fragments rendered don't make much sense.

Additionally, git will also output lines of `...` , which the FZF preview trips up over, and appears to render the diff back from `HEAD`. This is particularly frustrating in larger repositories, when only a fraction of commits affect the current buffer.

Before: _(showing nonsensical preview)_

```
 vim.vim
BCommits>   < 281/281 +S                           ┌────────────────────────────────────────────────┐
  :: Press CTRL-S to toggle sort, CTRL-D to diff   │ diff --git a/autoload/fzf/vim.vim b/autoload/f │
  * 19df93a (HEAD -> bcommits, mine/bcommits) do.. │ index c4af601..a88e8c5 100644                  │
  * b51382f (mine/master, mine/HEAD, master) [fz.. │ --- a/autoload/fzf/vim.vim                     │
  ...                                              │ +++ b/autoload/fzf/vim.vim                     │
  * 121bd70 [[B]Commits] Enable preview window b.. │ @@ -1070,7 +1070,7 @@ function! s:commits(buff │
  * b240389 Fix incorrect --query option in comp.. │      return s:warn('Not in git repository')    │
  * 36f6e6b Fix s:wrap for Vim 7.4 6 weeks ago     │    endif                                       │
  * 2fd046f [Files] Port junegunn/fzf/pull/1043 .. │                                                │
  * e7928d1 [Files] Do not set up lengthy prompt.. │ -  let source = 'git log '.get(g:, 'fzf_commit │
  * df79877 [fzf#vim#preview] works with Windows.. │ +  let source = 'git log '.get(g:, 'fzf_commit │
  * 0b0d9f0 [Ag] Print error message when ag is .. │    let current = expand('%')                   │
> ...                                              │    let managed = 0                             │
  | * 34ceec1 [fzf#vim#complete] append --no-exp.. │    if !empty(current)                          │
  | * b73cec5 [fzf#vim#complete#path] works in W.. │ @@ -1083,6 +1083,8 @@ function! s:commits(buff │
  | * 25ea637 [s:complete_trigger] use list type.. │        return s:warn('The current buffer is no │
  |/                                               │      endif                                     │
  * 4e603e4 [Commits] Fix formatting of commit l.. │      let source .= ' --follow '.fzf#shellescap │
  ...                                              │ +  else                                        │
  | * a4d4986 Make 8.3 filename via cmd.exe for .. │ +    let source .= ' --graph'                  │
  | * dda682a Revert "Run preview script in batc.. │    endif                                       │
  | * 71cc4c5 Run preview script in batchfile fo.. │                                                │
  | * 057853a [s:fzf] join the option list for p.. │    let command = a:buffer_local ? 'BCommits' : │
  | * 3334d62 [fzf#vim#with_preview] works with .. │                                                │
  | * 469ac6b [Ag] works in Windows 9 weeks ago    └────────────────────────────────────────────────┘
 > fzf
```

After:

```
 vim.vim
BCommits>   < 214/214 +S                           ┌────────────────────────────────────────────────┐
  :: Press CTRL-S to toggle sort, CTRL-D to diff   │ diff --git a/autoload/fzf/vim.vim b/autoload/f │
> 19df93a (HEAD -> bcommits, mine/bcommits) don'.. │ index c4af601..a88e8c5 100644                  │
  b51382f (mine/master, mine/HEAD, master) [fzf#.. │ --- a/autoload/fzf/vim.vim                     │
  121bd70 [[B]Commits] Enable preview window by .. │ +++ b/autoload/fzf/vim.vim                     │
  b240389 Fix incorrect --query option in comple.. │ @@ -1070,7 +1070,7 @@ function! s:commits(buff │
  36f6e6b Fix s:wrap for Vim 7.4 6 weeks ago       │      return s:warn('Not in git repository')    │
  2fd046f [Files] Port junegunn/fzf/pull/1043 (#.. │    endif                                       │
  e7928d1 [Files] Do not set up lengthy prompt o.. │                                                │
  df79877 [fzf#vim#preview] works with Windows d.. │ -  let source = 'git log '.get(g:, 'fzf_commit │
  0b0d9f0 [Ag] Print error message when ag is no.. │ +  let source = 'git log '.get(g:, 'fzf_commit │
  34ceec1 [fzf#vim#complete] append --no-expect .. │    let current = expand('%')                   │
  b73cec5 [fzf#vim#complete#path] works in Windo.. │    let managed = 0                             │
  25ea637 [s:complete_trigger] use list type for.. │    if !empty(current)                          │
  4e603e4 [Commits] Fix formatting of commit log.. │ @@ -1083,6 +1083,8 @@ function! s:commits(buff │
  e246016 [History] Remove duplicates and print .. │        return s:warn('The current buffer is no │
  a4d4986 Make 8.3 filename via cmd.exe for Neov.. │      endif                                     │
  b0baf75 [Commits,BCommits] Windows support (#4.. │      let source .= ' --follow '.fzf#shellescap │
  dda682a Revert "Run preview script in batchfil.. │ +  else                                        │
  71cc4c5 Run preview script in batchfile for Wi.. │ +    let source .= ' --graph'                  │
  057853a [s:fzf] join the option list for previ.. │    endif                                       │
  3334d62 [fzf#vim#with_preview] works with Ag i.. │                                                │
  469ac6b [Ag] works in Windows 9 weeks ago        │    let command = a:buffer_local ? 'BCommits' : │
  fa91d53 [Tags] Support Windows-style absolute .. │                                                │
  1e40de4 [Tags, BTags] Windows support (#427) 9.. └────────────────────────────────────────────────┘
 > fzf
```

The output of `:Commits` is unaffected by this PR; the `--graph` makes sense there.