### PR TITLE
Allow customizing btags command by file type

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -747,9 +747,15 @@ function! fzf#vim#buffer_tags(query, ...)
   let args = copy(a:000)
   let escaped = fzf#shellescape(expand('%'))
   let null = s:is_win ? 'nul' : '/dev/null'
-  let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s 2> %s', &filetype, escaped, null),
-    \ printf('ctags -f - --sort=no --excmd=number %s 2> %s', escaped, null)]
+  if (len(args) > 1 && type(args[0]) != type({}))
+      let tag_cmds = remove(args, 0)
+  elseif (exists('g:fzf_btags_command') && has_key(g:fzf_btags_command, &filetype))
+      let tag_cmds = printf(g:fzf_btags_command[&filetype], escaped)
+  else
+      let tag_cmds = [
+        \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s 2> %s', &filetype, escaped, null),
+        \ printf('ctags -f - --sort=no --excmd=number %s 2> %s', escaped, null)]
+  endif
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]
   endif

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -186,7 +186,7 @@ Command-local options~
                                                  *fzf-vim-command-local-options*
 
                *g:fzf_buffers_jump* *g:fzf_commits_log_options* *g:fzf_tags_command*
-                                                         *g:fzf_commands_expect*
+                                     *g:fzf_btags_command* *g:fzf_commands_expect*
 >
     " [Buffers] Jump to the existing window if possible
     let g:fzf_buffers_jump = 1
@@ -196,6 +196,10 @@ Command-local options~
 
     " [Tags] Command to generate tags file
     let g:fzf_tags_command = 'ctags -R'
+
+    " [BTags] Command to generate tags for a buffer (%s will be formatted to
+    " file name)
+    let g:fzf_btags_command = {'go': 'gotags -silent -sort %s | sed /^!_TAG_/d'}
 
     " [Commands] --expect expression for directly executing the command
     let g:fzf_commands_expect = 'alt-enter,ctrl-x'


### PR DESCRIPTION
This allows the optional setting of g:fzf_btags_command to a dict that
maps a filetype to a command string that will generate tags for the
current buffer.

Eg:
```
let g:fzf_btags_command = {'go': 'gotags -silent -sort %s'}
```
This is to resolve the issue seen in #389 in a similar way to CtrlP