### PR TITLE
Escape invocation to preview.rb.

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -30,7 +30,7 @@ set cpo&vim
 
 let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
-let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
+let s:bin_dir = fnameescape(expand('<sfile>:h:h:h').'/bin/')
 let s:bin = {
 \ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
 \ 'tags':    s:bin_dir.'tags.pl' }


### PR DESCRIPTION
If the Vim runtime directory is located in a directory with spaces, preview will fail.