### PR TITLE
[GitFiles] Support files with special characters

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -495,9 +495,9 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  'git ls-files '.a:args,
+    \ 'source':  'git ls-files -z '.a:args,
     \ 'dir':     root,
-    \ 'options': '-m --prompt "GitFiles> "'
+    \ 'options': '--read0 -m --prompt "GitFiles> "'
     \}, a:000)
   endif
 


### PR DESCRIPTION
By default git will quote filenames that contain special characters.
From the git help on the `core.quotepath` config:

> The commands that output paths (e.g. `ls-files`, `diff`), when not given
> the `-z` option, will quote "unusual" characters in the pathname by
> enclosing the pathname in a double-quote pair and with backslashes the
> same way strings in C source code are quoted. If this variable is set
> to false, the bytes higher than 0x80 are not quoted but output as
> verbatim. Note that double quote, backslash and control characters are
> always quoted without `-z` regardless of the setting of this variable.

This quoting behaviour means that GitFiles cannot be used to open files
that contain any special characters. Fix this by using the `-z` option
to `ls-files` together with the `--read0` option on fzf.