### PR TITLE
Add fzf#vim#rg_raw to enable fine grained ripgrep search

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -670,6 +670,14 @@ function! fzf#vim#ag_raw(command_suffix, ...)
   return call('fzf#vim#grep', extend(['ag --nogroup --column --color '.a:command_suffix, 1], a:000))
 endfunction
 
+" rg command suffix, [options]
+function! fzf#vim#rg_raw(command_suffix, ...)
+  if !executable('rg')
+    return s:warn('rg is not found')
+  endif
+  return call('fzf#vim#grep', extend(['rg --column --line-number --no-heading --color=always '.a:command_suffix, 1], a:000))
+endfunction
+
 " command, with_column, [options]
 function! fzf#vim#grep(grep_command, with_column, ...)
   let words = []


### PR DESCRIPTION
Although ripgrep is supported in fzf.vim, it is not possible (to my knowledge) to pass on custom parameters ( similar to issue #92 ). Most importantly I couldn't find a way to specify a path or a glob.

Analogously to fzf#vim#rg_raw, this would add the function fzf#vim#rg_raw

One could then define the following function to the .vimrc: 

    command! -bang -nargs=* Rgraw
      \ call fzf#vim#rg_raw(<q-args>,
      \   <bang>0 ? fzf#vim#with_preview('up:60%')
      \           : fzf#vim#with_preview('right:50%:hidden', '?'),
      \   <bang>0)

Ultimately, this would allow a "raw" ripgrep search by specifying a pattern and a path: 

    :Rgraw test ~/mypath

It also allows for more fine grained control exploiting the ripgrep parameters (note, "!" enables the preview window):

    Rgraw! -e pattern1 -e pattern -g *.txt ~/mypath

