### PR TITLE
[Tags] Configurable `fzf` command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -839,12 +839,24 @@ function! fzf#vim#tags(query, ...)
       break
     endif
   endfor
-  let opts = v2_limit < 0 ? '--algo=v1 ' : ''
+
+  let opts = []
+
+  if v2_limit < 0
+    add(opts, '--algo=v1')
+  endif
+  if exists('g:fzf_tags_command_tags_flags')
+    add(opts, g:fzf_tags_command_flags)
+  else
+    add(opts, '--nth 1..2 -m --tiebreak=begin')
+  endif
+
+  let cmd_options = join(opts, ' ')
 
   return s:fzf('tags', {
   \ 'source':  fzf#shellescape(s:bin.tags).' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
   \ 'sink*':   s:function('s:tags_sink'),
-  \ 'options': opts.'--nth 1..2 -m --tiebreak=begin --prompt "Tags> "'.s:q(a:query)}, a:000)
+  \ 'options': cmd_options.' --prompt "Tags> "'.s:q(a:query)}, a:000)
 endfunction
 
 " ------------------------------------------------------------------

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -198,6 +198,8 @@ Command-local options~
 
     " [Tags] Command to generate tags file
     let g:fzf_tags_command = 'ctags -R'
+    " [Tags] Flags for 'fzf' command. (See 'fzf --help' for full list)
+    let g:fzf_tags_command_flags = '--nth 1..2 -m --tiebreak=begin'
 
     " [Commands] --expect expression for directly executing the command
     let g:fzf_commands_expect = 'alt-enter,ctrl-x'


### PR DESCRIPTION
Allows to override flags for `fzf` command to resolve issue when `--nth
1..2` flag is not enough (for example for tags with spaces)
See: https://github.com/junegunn/fzf.vim/issues/519