### PR TITLE
[fzf#vim#with_preview] workaround system() newline on Neovim

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -37,7 +37,7 @@ let s:bin = {
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 if s:is_win
   if has('nvim')
-    let s:bin.preview = split(system('for %A in ("'.s:bin.preview.'") do echo %~sA'), "\n")[1]
+    let s:bin.preview = split(system('for %A in ("'.s:bin.preview.'") do @echo %~sA'), "\n")[0]
   else
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
   endif


### PR DESCRIPTION
Related: https://github.com/neovim/neovim/issues/7788

On Vim, it's `ruby path\\to\\bin\\preview.rb`.
On Neovim, it's `ruby > path\\to\\bin\\preview.rb`

The patch reduces the output to a single line so the extra newline doesn't affect `s:bin.preview`.