### PR TITLE
[fzf#vim#with_preview] Escape preview script path

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -97,7 +97,7 @@ function! fzf#vim#with_preview(...)
     call remove(args, 0)
   endif
 
-  let preview = ['--preview-window', window, '--preview', s:bin.preview.' '.(window =~ 'up\|down' ? '-v' : '').' {}']
+  let preview = ['--preview-window', window, '--preview', (s:is_win ? s:bin.preview : fzf#shellescape(s:bin.preview)).' '.(window =~ 'up\|down' ? '-v' : '').' {}']
 
   if len(args)
     call extend(preview, ['--bind', join(map(args, 'v:val.":toggle-preview"'), ',')])


### PR DESCRIPTION
Related: https://github.com/junegunn/fzf.vim/pull/493
Close: https://github.com/junegunn/fzf.vim/issues/554