### PR TITLE
[Tags] run perl for s:bin.tags

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -842,7 +842,7 @@ function! fzf#vim#tags(query, ...)
   let opts = v2_limit < 0 ? '--algo=v1 ' : ''
 
   return s:fzf('tags', {
-  \ 'source':  fzf#shellescape(s:bin.tags).' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
+  \ 'source':  'perl '.fzf#shellescape(s:bin.tags).' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
   \ 'sink*':   s:function('s:tags_sink'),
   \ 'options': opts.'--nth 1..2 -m --tiebreak=begin --prompt "Tags> "'.s:q(a:query)}, a:000)
 endfunction


### PR DESCRIPTION
Close: https://github.com/junegunn/fzf.vim/issues/553

This should allow Windows users to not require associating `pl` file extension with perl and avoid opening notepad.exe (default behaviour).
Personally, I don't need it because I use the installer from http://strawberryperl.com/ but msysgit comes with perl.exe already.