### PR TITLE
Use b:term_title for Neovim terminal buffers

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -577,12 +577,15 @@ endfunction
 
 function! s:format_buffer(b)
   let name = bufname(a:b)
+  let is_terminal = name =~? 'term://.*$'
+  let name = is_terminal ? getbufvar(a:b, 'term_title') : name
   let name = empty(name) ? '[No Name]' : fnamemodify(name, ":~:.")
   let flag = a:b == bufnr('')  ? s:blue('%', 'Conditional') :
           \ (a:b == bufnr('#') ? s:magenta('#', 'Special') : ' ')
   let modified = getbufvar(a:b, '&modified') ? s:red(' [+]', 'Exception') : ''
+  let terminal = is_terminal ? s:green(' [Terminal]', 'Constant') : ''
   let readonly = getbufvar(a:b, '&modifiable') ? '' : s:green(' [RO]', 'Constant')
-  let extra = join(filter([modified, readonly], '!empty(v:val)'), '')
+  let extra = join(filter([modified, terminal, readonly], '!empty(v:val)'), '')
   return s:strip(printf("[%s] %s\t%s\t%s", s:yellow(a:b, 'Number'), flag, name, extra))
 endfunction
 


### PR DESCRIPTION
This PR updates the Buffers command to use `b:term_title` for Neovim terminal buffers. This is the same as the buffer name by default. If you have your shell set up to change the terminal title when changing directories, running programs etc it will be displayed instead, which makes it easier to navigate between interactive terminal buffers.

I've also added a [Terminal] indicator as a custom terminal title might be ambiguous otherwise.