### PR TITLE
Change :GGrep example to work at project level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ You can use autoload functions to define your own commands.
 " Command for git grep
 " - fzf#vim#grep(command, with_column, [options], [fullscreen])
 command! -bang -nargs=* GGrep
-  \ lcd `=fnameescape(split(system('git rev-parse --show-toplevel'), '\n')[0])` | call fzf#vim#grep('git grep --line-number '.shellescape(<q-args>), 0, <bang>0)
+  \ call fzf#vim#grep(
+  \   'git grep --line-number '.shellescape(<q-args>), 0,
+  \   { 'dir': systemlist('git rev-parse --show-toplevel')[0] }, <bang>0)
 
 " Override Colors command. You can safely do this in your .vimrc as fzf.vim
 " will not override existing commands.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can use autoload functions to define your own commands.
 " Command for git grep
 " - fzf#vim#grep(command, with_column, [options], [fullscreen])
 command! -bang -nargs=* GGrep
-  \ call fzf#vim#grep('git grep --line-number '.shellescape(<q-args>), 0, <bang>0)
+  \ call fzf#vim#grep('cd ' . split(system('git rev-parse --show-toplevel'), '\n')[0] . ' && git grep --line-number '.shellescape(<q-args>), 0, <bang>0)
 
 " Override Colors command. You can safely do this in your .vimrc as fzf.vim
 " will not override existing commands.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can use autoload functions to define your own commands.
 " Command for git grep
 " - fzf#vim#grep(command, with_column, [options], [fullscreen])
 command! -bang -nargs=* GGrep
-  \ call fzf#vim#grep('cd ' . split(system('git rev-parse --show-toplevel'), '\n')[0] . ' && git grep --line-number '.shellescape(<q-args>), 0, <bang>0)
+  \ lcd `=fnameescape(split(system('git rev-parse --show-toplevel'), '\n')[0])` | call fzf#vim#grep('git grep --line-number '.shellescape(<q-args>), 0, <bang>0)
 
 " Override Colors command. You can safely do this in your .vimrc as fzf.vim
 " will not override existing commands.


### PR DESCRIPTION
Do this so it matches the ~official :GFiles

You are of course welcome to decline this change.  I just found this much more useful.  I fooled around a little bit with actually moving this into the plugin proper, but my vimscript abilities weren't quite up to the job.