### PR TITLE
buffer_tags: sort tags

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -745,8 +745,8 @@ function! fzf#vim#buffer_tags(query, ...)
   let escaped = fzf#shellescape(expand('%'))
   let null = s:is_win ? 'nul' : '/dev/null'
   let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=no --excmd=number --language-force=%s %s 2> %s', &filetype, escaped, null),
-    \ printf('ctags -f - --sort=no --excmd=number %s 2> %s', escaped, null)]
+    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s', &filetype, escaped, null),
+    \ printf('ctags -f - --sort=yes --excmd=number %s 2> %s', escaped, null)]
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]
   endif


### PR DESCRIPTION
This is nice for (ab)using :BTags to "browse" functions in a source file.

I assume `--sort=no` was used for performance, but on a single file maybe that doesn't matter?