### PR TITLE
Add fzf-complete-path-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,18 +216,19 @@ command! -bang -nargs=? -complete=dir Files
 Mappings
 --------
 
-| Mapping                            | Description                               |
-| ---                                | ---                                       |
-| `<plug>(fzf-maps-n)`               | Normal mode mappings                      |
-| `<plug>(fzf-maps-i)`               | Insert mode mappings                      |
-| `<plug>(fzf-maps-x)`               | Visual mode mappings                      |
-| `<plug>(fzf-maps-o)`               | Operator-pending mappings                 |
-| `<plug>(fzf-complete-word)`        | `cat /usr/share/dict/words`               |
-| `<plug>(fzf-complete-path)`        | Path completion using `find` (file + dir) |
-| `<plug>(fzf-complete-file)`        | File completion using `find`              |
-| `<plug>(fzf-complete-file-ag)`     | File completion using `ag`                |
-| `<plug>(fzf-complete-line)`        | Line completion (all open buffers)        |
-| `<plug>(fzf-complete-buffer-line)` | Line completion (current buffer only)     |
+| Mapping                              | Description                                 |
+| ---                                  | ---                                         |
+| `<plug>(fzf-maps-n)`                 | Normal mode mappings                        |
+| `<plug>(fzf-maps-i)`                 | Insert mode mappings                        |
+| `<plug>(fzf-maps-x)`                 | Visual mode mappings                        |
+| `<plug>(fzf-maps-o)`                 | Operator-pending mappings                   |
+| `<plug>(fzf-complete-word)`          | `cat /usr/share/dict/words`                 |
+| `<plug>(fzf-complete-path)`          | Path completion using `find` (file + dir)   |
+| `<plug>(fzf-complete-path-relative)` | Generate relative path (starting ./ or ../) |
+| `<plug>(fzf-complete-file)`          | File completion using `find`                |
+| `<plug>(fzf-complete-file-ag)`       | File completion using `ag`                  |
+| `<plug>(fzf-complete-line)`          | Line completion (all open buffers)          |
+| `<plug>(fzf-complete-buffer-line)`   | Line completion (current buffer only)       |
 
 ### Usage
 

--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -54,6 +54,7 @@ endfunction
 
 " ----------------------------------------------------------------------------
 " <plug>(fzf-complete-path)
+" <plug>(fzf-complete-path-relative)
 " <plug>(fzf-complete-file)
 " <plug>(fzf-complete-file-ag)
 " ----------------------------------------------------------------------------
@@ -123,6 +124,32 @@ function! s:fname_prefix(str)
   endfor
 
   return prefix
+endfunction
+
+function! s:generate_relative(path)
+  let target = getcwd() . '/' . (join(a:path))
+  let base = expand('%:p:h')
+
+  let prefix = ""
+  while stridx(target, base) != 0
+    let base = substitute(system('dirname ' . base), '\n\+$', '', '')
+    let prefix = '../' . prefix
+  endwhile
+
+  if prefix == ''
+    let prefix = './'
+  endif
+
+  return prefix . substitute(target, base . '/', '', '')
+endfunction
+
+function! fzf#vim#complete#path_relative(command, ...)
+  let s:file_cmd = a:command
+  return fzf#vim#complete(s:extend({
+  \ 'prefix':  s:function('s:fname_prefix'),
+  \ 'source':  s:function('s:file_source'),
+  \ 'options': s:function('s:file_options'),
+  \ 'reducer': s:function('s:generate_relative')}, get(a:000, 0, fzf#wrap())))
 endfunction
 
 function! fzf#vim#complete#path(command, ...)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -123,17 +123,19 @@ augroup fzf_buffers
   autocmd BufDelete * silent! call remove(g:fzf#vim#buffers, expand('<abuf>'))
 augroup END
 
-inoremap <expr> <plug>(fzf-complete-word)        fzf#vim#complete#word()
+inoremap <expr> <plug>(fzf-complete-word)            fzf#vim#complete#word()
 if s:is_win
-  inoremap <expr> <plug>(fzf-complete-path)      fzf#vim#complete#path('dir /s/b')
-  inoremap <expr> <plug>(fzf-complete-file)      fzf#vim#complete#path('dir /s/b/a:-d')
+  inoremap <expr> <plug>(fzf-complete-path)           fzf#vim#complete#path('dir /s/b')
+  inoremap <expr> <plug>(fzf-complete-path-relative)  fzf#vim#complete#path_relative('dir /s/b/')
+  inoremap <expr> <plug>(fzf-complete-file)           fzf#vim#complete#path('dir /s/b/a:-d')
 else
-  inoremap <expr> <plug>(fzf-complete-path)      fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
-  inoremap <expr> <plug>(fzf-complete-file)      fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
+  inoremap <expr> <plug>(fzf-complete-path)           fzf#vim#complete#path("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
+  inoremap <expr> <plug>(fzf-complete-path-relative)  fzf#vim#complete#path_relative("find . -path '*/\.*' -prune -o -print \| sed '1d;s:^..::'")
+  inoremap <expr> <plug>(fzf-complete-file)           fzf#vim#complete#path("find . -path '*/\.*' -prune -o -type f -print -o -type l -print \| sed 's:^..::'")
 endif
-inoremap <expr> <plug>(fzf-complete-file-ag)     fzf#vim#complete#path('ag -l -g ""')
-inoremap <expr> <plug>(fzf-complete-line)        fzf#vim#complete#line()
-inoremap <expr> <plug>(fzf-complete-buffer-line) fzf#vim#complete#buffer_line()
+inoremap <expr> <plug>(fzf-complete-file-ag)          fzf#vim#complete#path('ag -l -g ""')
+inoremap <expr> <plug>(fzf-complete-line)             fzf#vim#complete#line()
+inoremap <expr> <plug>(fzf-complete-buffer-line)      fzf#vim#complete#buffer_line()
 
 nnoremap <silent> <plug>(fzf-maps-n) :<c-u>call fzf#vim#maps('n', 0)<cr>
 inoremap <silent> <plug>(fzf-maps-i) <c-o>:call fzf#vim#maps('i', 0)<cr>


### PR DESCRIPTION
Hello @junegunn 

I've implemented a solution for a feature discussed in https://github.com/junegunn/fzf.vim/issues/303

Basic use case is to fuzzyfind a file and insert path to it that is relative to buffer.

It helps a lot with languages that do not have library paths (e.g. JavaScript).

Maybe it can help somebody save some time.

Cheers,
