### PR TITLE
Clean up buffer names in :Buffers

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -577,7 +577,7 @@ endfunction
 
 function! s:format_buffer(b)
   let name = bufname(a:b)
-  let name = empty(name) ? '[No Name]' : fnamemodify(name, ":~:.")
+  let name = empty(name) ? '[No Name]' : fnamemodify(name, ":p:~:.")
   let flag = a:b == bufnr('')  ? s:blue('%', 'Conditional') :
           \ (a:b == bufnr('#') ? s:magenta('#', 'Special') : ' ')
   let modified = getbufvar(a:b, '&modified') ? s:red(' [+]', 'Exception') : ''


### PR DESCRIPTION
Issue: While following paths in a file, it might end up in paths like
`a/b/../c/d.ext` or `a/b/./c.ext`, which would be cleaner if displayed
like `a/c/d.ext` and `a/b/c.ext`.

Solution: Expand fullpath to resolve directories before collapsing it to
home directory/relative path.