### PR TITLE
Allow to search for multi-word tags.

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -836,7 +836,7 @@ function! fzf#vim#tags(query, ...)
   return s:fzf('tags', {
   \ 'source':  'perl '.fzf#shellescape(s:bin.tags).' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
   \ 'sink*':   s:function('s:tags_sink'),
-  \ 'options': extend(opts, ['--nth', '1..2', '-m', '--tiebreak=begin', '--prompt', 'Tags> ', '--query', a:query])}, a:000)
+  \ 'options': extend(opts, ['--nth', '1', '-d', '\t', '-m', '--tiebreak=begin', '--prompt', 'Tags> ', '--query', a:query])}, a:000)
 endfunction
 
 " ------------------------------------------------------------------


### PR DESCRIPTION
Any reason to use `--nth 1..2` in here? It doesn't work with tags that have multiple spaces in them.
Standard CTags format (man ctags) uses: `tag_name<TAB>file_name<TAB>ex_cmd;"<TAB>extension_fields`. That's why I think that the delimiter should be a `<TAB>`.
