### PR TITLE
[Buffers] Add a custom filename_modifier for "Buffers" command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -576,8 +576,9 @@ function! s:bufopen(lines)
 endfunction
 
 function! s:format_buffer(b)
+  let filename_modifier = get(g:, 'fzf_buffer_fnamemodify_arg', ":~:.")
   let name = bufname(a:b)
-  let name = empty(name) ? '[No Name]' : fnamemodify(name, ":p:~:.")
+  let name = empty(name) ? '[No Name]' : fnamemodify(name, filename_modifier)
   let flag = a:b == bufnr('')  ? s:blue('%', 'Conditional') :
           \ (a:b == bufnr('#') ? s:magenta('#', 'Special') : ' ')
   let modified = getbufvar(a:b, '&modified') ? s:red(' [+]', 'Exception') : ''


### PR DESCRIPTION
This allows users to specify in their .vimrc a specific
filename_modifier in order to customize how their :Buffers list
looks. I didn't need the full path, so I wanted to be able to view
just the filenames themselves.

This allows users to specify something like this in their .vimrc:
`let g:fzf_buffer_fnamemodify_arg=":t"`

This would make the `:Buffers` command show up like:
`> [1] # foo.txt`
Instead of the standard:
`> [1] # /path/to/foo.txt`


I also couldn't find any contribution guidelines. I'd be happy to format anything as required.