### PR TITLE
Unfold after Lines/BLines

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -316,7 +316,7 @@ function! s:line_handler(lines)
   let keys = split(a:lines[1], '\t')
   execute 'buffer' keys[0]
   execute keys[2]
-  normal! ^zzzv
+  normal! ^zvzz
 endfunction
 
 function! fzf#vim#_lines(all)
@@ -384,7 +384,7 @@ function! s:buffer_line_handler(lines)
   endif
 
   execute split(a:lines[1], '\t')[0]
-  normal! ^zzzv
+  normal! ^zvzz
 endfunction
 
 function! s:buffer_lines()

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -316,7 +316,7 @@ function! s:line_handler(lines)
   let keys = split(a:lines[1], '\t')
   execute 'buffer' keys[0]
   execute keys[2]
-  normal! ^zz
+  normal! ^zzzv
 endfunction
 
 function! fzf#vim#_lines(all)
@@ -384,7 +384,7 @@ function! s:buffer_line_handler(lines)
   endif
 
   execute split(a:lines[1], '\t')[0]
-  normal! ^zz
+  normal! ^zzzv
 endfunction
 
 function! s:buffer_lines()


### PR DESCRIPTION
Actually I would want the unfold to only happen, if the matched line is really hidden within a fold. In the current version of the PR, the fold will also be unfolded when the matched line is the beginning of the fold. Unfortunately, I did not find any way to tell, if the current line is hidden within a fold. 