### PR TITLE
Add option to disable colored output for Ag and Rg

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -690,7 +690,8 @@ function! fzf#vim#ag_raw(command_suffix, ...)
   if !executable('ag')
     return s:warn('ag is not found')
   endif
-  return call('fzf#vim#grep', extend(['ag --nogroup --column --color '.a:command_suffix, 1], a:000))
+  let color = get(g:, 'fzf_ag_no_color') ? '--nocolor' : '--color'
+  return call('fzf#vim#grep', extend(['ag --nogroup --column '.color.' '.a:command_suffix, 1], a:000))
 endfunction
 
 " command, with_column, [options]


### PR DESCRIPTION
My most common use case of fzf.vim is to do a blanket ':Ag' or ':Rg' (actually it's a custom command) to fuzzy find on all lines in the project then do stuff with the results. However, Ag and Rg take much longer to output all lines in a project when color is enabled.

I'd like to add a feature to disable colored output for Rg, Ag, or both; I don't care about the specifics of how fine-grained the control is, I would want to disable it on both.

I've tested it for Ag, but I don't know how to conveniently add the switch for color on/off to the Rg command because of the way you implemented it and the fact that I don't know how to write vimscript. So adding it there, which is useful to me because I prefer rg over ag, will require some guidance.

Also, assuming you're okay with adding this feature, I'd like to put a note on the readme about disabling color to speed up output for a large number of lines.