### PR TITLE
Configurable preview highlighter for Linux

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -55,7 +55,6 @@ else
       endif
     endfor
   endif
-  echom s:preview_highlighter
   let s:preview_line_highlight = get(g:, 'fzf_preview_line_highlight', '\x1b[7m')
   let s:bin.preview = 'CENTER={2};FIRST=$(($CENTER-$LINES/4));FIRST=$(($FIRST<1?1:$FIRST));'.s:preview_highlighter.' {1}|sed -n "$FIRST,+50{${CENTER}{s/\x1b\[[0-9;]*m/&' . s:preview_line_highlight . '/g;s/$/\x1b[m/};p}"'
 endif


### PR DESCRIPTION
I would like to pass custom options to highlighters used for previews (for example to select a specific color theme for `highlight`).

This PR is to add a new configuration variable `g:fzf_preview_highlighter` that allows to specify which highlighter to use with specific command line options.

**The implementation works only on Linux (successfully tested) and probably on Mac (can someone test and confirm please?).** I don't have Windows, would be glad if someone could adapt changes for it :)

Example:

```vim
let g:fzf_preview_highlighter = "highlight -O xterm256 --line-number --style rdark --force"
```
allows to use `highlight` with the `rdark` theme.

If the `g:fzf_preview_highlighter` variable is not set,  the default behavior is similar to `preview.rb`: check if `highlight`, `coderay`, `rougify` and `cat` exist, and use the first one available.

There is also a new `g:fzf_preview_line_highlight` variable that allows to specify the ansi color code used to highlight the line in the preview window that corresponds to the selected one in the list. Default value is `\x1b[7m` ("REVERSE", the same color code used in `preview.rb`). 

Examples:

To highlight the line with the bright black background color, use:
```vim
let g:fzf_preview_line_highlight = '\x1b[101m'
```

For terminals supporting 256-colors, you can specify a 8-bit color code:
```vim
let g:fzf_preview_line_highlight = '\x1b[48;5;240m'
```

You can even specify a 24-bit (true color) color code for terminals supporting it like Konsole:
```vim
let g:fzf_preview_line_highlight = '\x1b[48;2;80;80;80m'
```

Screenshot:

![vim_enhanced_fzf_preview](https://user-images.githubusercontent.com/454315/46251245-dcc19480-c44d-11e8-82e6-7915cfdc068a.png)

