### PR TITLE
Support bat for syntax highlighting in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ command! -bang Colors
 " Augmenting Ag command using fzf#vim#with_preview function
 "   * fzf#vim#with_preview([[options], preview window, [toggle keys...]])
 "     * For syntax-highlighting, Ruby and any of the following tools are required:
+"       - Bat: https://github.com/sharkdp/bat
 "       - Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
 "       - CodeRay: http://coderay.rubychan.de/
 "       - Rouge: https://github.com/jneen/rouge
-"       - Bat: https://github.com/sharkdp/bat
 "
 "   :Ag  - Start fzf with hidden preview window that can be enabled with "?" key
 "   :Ag! - Start fzf in fullscreen and display the preview window above

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ command! -bang Colors
 "       - Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
 "       - CodeRay: http://coderay.rubychan.de/
 "       - Rouge: https://github.com/jneen/rouge
+"       - Bat: https://github.com/sharkdp/bat
 "
 "   :Ag  - Start fzf with hidden preview window that can be enabled with "?" key
 "   :Ag! - Start fzf in fullscreen and display the preview window above

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -32,7 +32,7 @@ let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
 let s:bin = {
-\ 'preview': s:bin_dir.(executable('ruby') ? 'preview.rb' : 'preview.sh'),
+\ 'preview': s:bin_dir.'preview.sh',
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 if s:is_win

--- a/bin/preview.rb
+++ b/bin/preview.rb
@@ -4,7 +4,7 @@
 
 require 'shellwords'
 
-COMMAND = %[(highlight -O ansi -l {} || coderay {} || rougify {} || cat {}) 2> /dev/null]
+COMMAND = %[(highlight -O ansi -l {} || coderay {} || rougify {} || bat --style=numbers --color=always {} || cat {}) 2> /dev/null]
 ANSI    = /\x1b\[[0-9;]*m/
 REVERSE = "\x1b[7m"
 RESET   = "\x1b[m"
@@ -55,3 +55,4 @@ IO.popen(['sh', '-c', COMMAND.gsub('{}', Shellwords.shellescape(path))]) do |io|
     end
   end
 end
+print RESET

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -52,4 +52,16 @@ FIRST=$(($CENTER-$LINES/3))
 FIRST=$(($FIRST < 1 ? 1 : $FIRST))
 LAST=$((${FIRST}+${LINES}-1))
 
-awk "NR >= $FIRST && NR <= $LAST {if (NR == $CENTER) printf(\"$REVERSE%5d %s\n$RESET\", NR, \$0); else printf(\"%5d %s\n\", NR, \$0)}" $FILE
+if which bat >/dev/null; then
+  CAT="bat --style=numbers --color=always"
+  $CAT $FILE | awk "NR >= $FIRST && NR <= $LAST { \
+      if (NR == $CENTER) \
+          { gsub(/\x1b[[0-9;]*m/, \"&$REVERSE\"); printf(\"$REVERSE%s\n$RESET\", \$0); } \
+      else printf(\"$RESET%s\n\", \$0); \
+      }"
+else
+  awk "NR >= $FIRST && NR <= $LAST { \
+      if (NR == $CENTER) printf(\"$REVERSE%5d %s\n$RESET\", NR, \$0); \
+      else printf(\"%5d %s\n\", NR, \$0); \
+      }" $FILE
+fi


### PR DESCRIPTION
[bat](https://github.com/sharkdp/bat) is a very nice clone of `cat` that supports syntax highlighting feature. If bat is available, one may want to have it as a syntax highlighter used in `preview.sh` or `preview.rb`. This PR adds the support.

I have implemented the functionality to be close to what `preview.sh` is doing, with `awk`. Of course, the use of `bat` is absolutely optional. It allows us to have a syntax highlighting feature even without ruby.

![image](https://user-images.githubusercontent.com/1009873/46586608-ed29ce80-ca4e-11e8-8152-5b4049d2d4f1.png)

Another note: it might conflict with #707.