### PR TITLE
Use `env` to get `bash`

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 REVERSE="\x1b[7m"
 RESET="\x1b[m"


### PR DESCRIPTION
This wasn't working on NixOS due to bash not being under `/bin`. Using `env` should make it compatible with more setups.