### PR TITLE
add g:fzf_lines_jump option to jump to existing viewport for Lines

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -325,6 +325,17 @@ function! s:line_handler(lines)
   endif
 
   let keys = split(a:lines[1], '\t')
+  if get(g:, 'fzf_lines_jump')
+      let b = matchstr(keys[0], '[0-9][0-9]*')
+      let [t, w] = s:find_open_window(b)
+      if t
+          call s:jump(t, w)
+          execute keys[2]
+          normal! ^zvzz
+          return
+      endif
+  endif
+
   execute 'buffer' keys[0]
   execute keys[2]
   normal! ^zvzz


### PR DESCRIPTION
add a new option like fzf_buffers_jump to switch to an existing window if present when using the Lines command