### PR TITLE
Use `{count}tabnext` instead of `normal {count}gt`

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -583,7 +583,7 @@ function! s:find_open_window(b)
 endfunction
 
 function! s:jump(t, w)
-  execute 'normal!' a:t.'gt'
+  execute a:t.'tabnext'
   execute a:w.'wincmd w'
 endfunction
 


### PR DESCRIPTION
Use `{count}tabnext` instead of `normal {count}gt` to avoid error that cannot re-enter normal mode in terminal mode in neovim.