### PR TITLE
Close buffers with --multi and ctrl+q

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ See [README-VIM.md][readme-vim] of the main fzf repository for details.
 ```vim
 " This is the default extra key bindings
 let g:fzf_action = {
+  \ 'ctrl-q': 'bdelete',
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
   \ 'ctrl-v': 'vsplit' }

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -219,6 +219,7 @@ function! s:fzf(name, opts, extra)
 endfunction
 
 let s:default_action = {
+  \ 'ctrl-q': 'bdelete',
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',
   \ 'ctrl-v': 'vsplit' }
@@ -591,19 +592,21 @@ function! s:bufopen(lines)
   if len(a:lines) < 2
     return
   endif
-  let b = matchstr(a:lines[1], '\[\zs[0-9]*\ze\]')
-  if empty(a:lines[0]) && get(g:, 'fzf_buffers_jump')
-    let [t, w] = s:find_open_window(b)
-    if t
-      call s:jump(t, w)
-      return
+  for line in a:lines[:1]
+    let b = matchstr(line, '\[\zs[0-9]*\ze\]')
+    if empty(a:lines[0]) && get(g:, 'fzf_buffers_jump')
+      let [t, w] = s:find_open_window(b)
+      if t
+        call s:jump(t, w)
+        return
+      endif
     endif
-  endif
-  let cmd = s:action_for(a:lines[0])
-  if !empty(cmd)
-    execute 'silent' cmd
-  endif
-  execute 'buffer' b
+    let cmd = s:action_for(a:lines[0])
+    if !empty(cmd)
+      execute 'silent' cmd
+    endif
+    execute 'buffer' b
+  endfor
 endfunction
 
 function! s:format_buffer(b)
@@ -633,7 +636,7 @@ function! fzf#vim#buffers(...)
   return s:fzf('buffers', {
   \ 'source':  map(s:buflisted_sorted(), 's:format_buffer(v:val)'),
   \ 'sink*':   s:function('s:bufopen'),
-  \ 'options': ['+m', '-x', '--tiebreak=index', '--header-lines=1', '--ansi', '-d', '\t', '-n', '2,1..2', '--prompt', 'Buf> ', '--query', query]
+  \ 'options': ['+m', '--multi', '-x', '--tiebreak=index', '--header-lines=1', '--ansi', '-d', '\t', '-n', '2,1..2', '--prompt', 'Buf> ', '--query', query]
   \}, args)
 endfunction
 

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -153,6 +153,7 @@ See {README-VIM.md}{4} of the main fzf repository for details.
 >
     " This is the default extra key bindings
     let g:fzf_action = {
+      \ 'ctrl-q': 'bdelete',
       \ 'ctrl-t': 'tab split',
       \ 'ctrl-x': 'split',
       \ 'ctrl-v': 'vsplit' }


### PR DESCRIPTION
Make buffers accept the multi version of fzf and run the command on all the selected items.

This enables a user to bdelete multiple buffers from within the :Buffers window.
This enables a user to vsplit multiple buffers.
etc.

Fixes #75