### PR TITLE
Do not remap keys when using feedkeys

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -896,7 +896,7 @@ function! s:command_sink(lines)
   endif
   let cmd = matchstr(a:lines[1], s:nbs.'\zs\S*\ze'.s:nbs)
   if empty(a:lines[0])
-    call feedkeys(':'.cmd.(a:lines[1][0] == '!' ? '' : ' '))
+    call feedkeys(':'.cmd.(a:lines[1][0] == '!' ? '' : ' '), 'n')
   else
     execute cmd
   endif


### PR DESCRIPTION
I have `;` and `:` swapped in my vimrc, so using the `:Commands` command is broken because `feedkeys` uses my remapped `:`. This PR tells `feedkeys` to not remap keys for the `:Commands` sink function.