### PR TITLE
expand '~' in preview

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -17,6 +17,7 @@ if [[ $1 =~ ^[A-Z]:\\ ]]; then
   CENTER=${INPUT[2]}
 fi
 
+FILE="${FILE/#\~/$HOME}"
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"
   exit 1


### PR DESCRIPTION
In preview mode, with this pull request it can correctly handle `~` in the path. Using `:call fzf#vim#history(fzf#vim#with_preview({'options': '--no-sort'}))` to test.