### PR TITLE
Add support for ctrl-a/ctrl-d in grep command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -711,7 +711,7 @@ function! fzf#vim#grep(grep_command, with_column, ...)
   \ 'source':  a:grep_command,
   \ 'column':  a:with_column,
   \ 'options': ['--ansi', '--prompt', capname.'> ',
-  \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
+  \             '--multi', '--bind', 'ctrl-a:select-all,ctrl-d:select-all,alt-a:select-all,alt-d:deselect-all',
   \             '--color', 'hl:4,hl+:12']
   \}
   function! opts.sink(lines)


### PR DESCRIPTION
ctrl-a/ctrl-d are easier to use in a default tmux environment.