### PR TITLE
Allow 'fzf-vim.txt' to be listed in the LOCAL ADDITIONS section of help.txt

### DIFF
--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -1,4 +1,4 @@
-fzf-vim.txt	fzf-vim	Last change: August 31 2018
+*fzf-vim.txt*	fzf-vim	Last change: August 31 2018
 FZF-VIM - TABLE OF CONTENTS                                *fzf-vim* *fzf-vim-toc*
 ==============================================================================
 


### PR DESCRIPTION
The first field on the first line of a help file should be a link to the help file name. (See :h help-writing)