### PR TITLE
Workaround for last-position-jump in :Tags

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -803,7 +803,7 @@ function! s:tags_sink(lines)
         let relpath = parts[1][:-2]
         let abspath = relpath =~ (s:is_win ? '^[A-Z]:\' : '^/') ? relpath : join([base, relpath], '/')
         call s:open(cmd, expand(abspath, 1))
-        execute excmd
+        silent execute excmd
         call add(qfl, {'filename': expand('%'), 'lnum': line('.'), 'text': getline('.')})
       catch /^Vim:Interrupt$/
         break


### PR DESCRIPTION
If there's an autocmd for BufReadPost that jumps to the last position,
searching for the tag location sometimes results in vim printing the
wrapscan warning and then requires hit-enter. Jump to the beginning
before searching for the tag to ensure consistent (no hit-enter)
behaviour.