### PR TITLE
Update how options are extended

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -303,7 +303,7 @@ function! fzf#vim#files(dir, ...)
   endif
 
   let args.options = ['-m', '--prompt', strwidth(dir) < &columns / 2 - 20 ? dir : '> ']
-  let args = s:merge_opts(args, get(g:, 'fzf_files_options', []))
+  let args = s:merge_opts(args, copy(get(g:, 'fzf_files_options', [])))
 
   return s:fzf('files', args, a:000)
 endfunction


### PR DESCRIPTION
Allow dictionaries to be used to extend the options provided to the base FZF plugin.

This will allow us to set `g:fzf_files_options` and set a different source so that we can influence the input to FZF's files command, e.g.,

```
let g:fzf_files_options = {'source': 'rg --files --no-ignore-vcs'} 
```

Will use ripgrep which will use `.ignore` but not `.gitignore`

-> Fold together option dictionaries verbatim

-> Extend `.options` with a list

-> Append / prepend .options string when not a dictionary

This will allow us to specify options for just the `files` command, addressing issue #453 without having to tweak an environment variable, and it allows for more flexibility in other commands if desired.