### PR TITLE
Enable configuration of the function used to retrieve the buffer list

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -193,8 +193,14 @@ for s:color_name in keys(s:ansi)
         \ "endfunction"
 endfor
 
+function! s:default_buffer_function()
+  return range(1, bufnr('$'))
+endfunction
+
 function! s:buflisted()
-  return filter(range(1, bufnr('$')), 'buflisted(v:val) && getbufvar(v:val, "&filetype") != "qf"')
+  let Buffunc = function(get(g:, "fzf_buffer_function", 's:default_buffer_function'))
+  return filter(Buffunc(), 'buflisted(v:val) && getbufvar(v:val, "&filetype") != "qf"')
+  endif
 endfunction
 
 function! s:fzf(name, opts, extra)


### PR DESCRIPTION
It's useful to enable configurability of the function used to retrieve the buffer list, so that certain buffers can be filtered, for example.

This pull request adds a new global variable which may contain the name of the function which provides the buffer list, allowing for extensibility of fzf's buffer related commands.