### PR TITLE
[Tags] Fix for when notagrelative is set

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -802,7 +802,8 @@ function! s:tags_sink(lines)
         let base    = fnamemodify(parts[-1], ':h')
         let relpath = parts[1][:-2]
         let abspath = relpath =~ (s:is_win ? '^[A-Z]:\' : '^/') ? relpath : join([base, relpath], '/')
-        call s:open(cmd, expand(abspath, 1))
+        let path    = &tagrelative == 0 ? relpath : abspath
+        call s:open(cmd, expand(path, 1))
         silent execute excmd
         call add(qfl, {'filename': expand('%'), 'lnum': line('.'), 'text': getline('.')})
       catch /^Vim:Interrupt$/


### PR DESCRIPTION
This PR addresses #761.

I have `set notagrelative` because I keep my tags file in the `.git` folder of my project as described [here](https://tbaggery.com/2011/08/08/effortless-ctags-with-git.html).

When I navigate to a tag with `:Tags`, it tries to open `.git/src/my-file` instead of `src/my-file`.

This PR fixes that problem while retaining the existing behavior with `set tagrelative`.