### PR TITLE
Bugfix: editing a command from history when colon is remapped

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -485,7 +485,7 @@ function! s:history_sink(type, lines)
   if key == 'ctrl-e'
     call histadd(a:type, item)
     redraw
-    call feedkeys(a:type."\<up>")
+    call feedkeys(a:type."\<up>", 'n')
   else
     if a:type == ':'
       call histadd(a:type, item)


### PR DESCRIPTION
Added `'n'` (to not remap keys) argument to `feedkeys` function.

I personally have `:` key remapped and `ctrl-e` doesn't work correctly for `:History:`.