### PR TITLE
Note on functions in fzf_action in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See [README-VIM.md][readme-vim] of the main fzf repository for details.
 
 ```vim
 " This is the default extra key bindings
+" Note, that fzf.vim does not support functions in fzf_action
 let g:fzf_action = {
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',


### PR DESCRIPTION
Had to dig through code and git blame to find b9b275a89, and understand, why :FZF calls my function and fzf.vim, while uses the very same dictionary, does not.