### PR TITLE
Use g:fzf_tags_command in BTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ let g:fzf_buffers_jump = 1
 let g:fzf_commits_log_options = '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
 
 " [Tags] Command to generate tags file
-let g:fzf_tags_command = 'ctags -R'
+let g:fzf_tags_command = 'ctags'
 
 " [Commands] --expect expression for directly executing the command
 let g:fzf_commands_expect = 'alt-enter,ctrl-x'

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -768,8 +768,8 @@ function! fzf#vim#buffer_tags(query, ...)
   let null = s:is_win ? 'nul' : '/dev/null'
   let sort = has('unix') && !has('win32unix') && executable('sort') ? '| sort -s -k 5' : ''
   let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', &filetype, escaped, null, sort),
-    \ printf('ctags -f - --sort=yes --excmd=number %s 2> %s %s', escaped, null, sort)]
+    \ printf(get(g:, 'fzf_tags_command', 'ctags').' -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', &filetype, escaped, null, sort),
+    \ printf(get(g:, 'fzf_tags_command', 'ctags').' -f - --sort=yes --excmd=number %s 2> %s %s', escaped, null, sort)]
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]
   endif
@@ -831,7 +831,7 @@ function! fzf#vim#tags(query, ...)
     redraw
     if gen =~? '^y'
       call s:warn('Preparing tags')
-      call system(get(g:, 'fzf_tags_command', 'ctags -R'.(s:is_win ? ' --output-format=e-ctags' : '')))
+      call system(get(g:, 'fzf_tags_command', 'ctags').' -R'.(s:is_win ? ' --output-format=e-ctags' : ''))
       if empty(tagfiles())
         return s:warn('Failed to create tags')
       endif

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -203,8 +203,8 @@ Command-local options~
     " [[B]Commits] Customize the options used by 'git log':
     let g:fzf_commits_log_options = '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'
 
-    " [Tags] Command to generate tags file
-    let g:fzf_tags_command = 'ctags -R'
+    " [[B]Tags] Exuberant Ctags command to generate tags file
+    let g:fzf_tags_command = 'ctags'
 
     " [Commands] --expect expression for directly executing the command
     let g:fzf_commands_expect = 'alt-enter,ctrl-x'


### PR DESCRIPTION
Resolves #196 

Also updates docs to clarify this will only work with exuberant ctags (or a derivative like universal ctags). The existing hard coded arguments are unlikely with other tag generators.