### PR TITLE
Add support for files in submodules when using BCommits/Commits

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1105,7 +1105,7 @@ function! s:commits(buffer_local, args)
     return s:warn('Not in git repository')
   endif
   let path = expand('%:p:h')
-  let source = 'git -C '.path.' log '.get(g:, 'fzf_commits_log_options', '--color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
+  let source = 'git -C '.fzf#shellescape(path).' log '.get(g:, 'fzf_commits_log_options', '--color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
   let current = expand('%')
   let managed = 0
   if !empty(current)
@@ -1116,7 +1116,7 @@ function! s:commits(buffer_local, args)
     if !managed
       return s:warn('The current buffer is not in the working tree')
     endif
-    let source .= ' --follow '.expand('%:t')
+    let source .= ' --follow '.fzf#shellescape(current)
   else
     let source .= ' --graph'
   endif

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1104,20 +1104,19 @@ function! s:commits(buffer_local, args)
   if empty(s:git_root)
     return s:warn('Not in git repository')
   endif
-
-  let source = 'git log '.get(g:, 'fzf_commits_log_options', '--color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
+  let path = expand('%:p:h')
+  let source = 'git -C '.path.' log '.get(g:, 'fzf_commits_log_options', '--color=always '.fzf#shellescape('--format=%C(auto)%h%d %s %C(green)%cr'))
   let current = expand('%')
   let managed = 0
   if !empty(current)
     call system('git show '.fzf#shellescape(current).' 2> '.(s:is_win ? 'nul' : '/dev/null'))
     let managed = !v:shell_error
   endif
-
   if a:buffer_local
     if !managed
       return s:warn('The current buffer is not in the working tree')
     endif
-    let source .= ' --follow '.fzf#shellescape(current)
+    let source .= ' --follow '.expand('%:t')
   else
     let source .= ' --graph'
   endif

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1112,6 +1112,7 @@ function! s:commits(buffer_local, args)
     call system('git show '.fzf#shellescape(current).' 2> '.(s:is_win ? 'nul' : '/dev/null'))
     let managed = !v:shell_error
   endif
+
   if a:buffer_local
     if !managed
       return s:warn('The current buffer is not in the working tree')


### PR DESCRIPTION
If file in buffer is located in submodule then bcommit doesn't show the history of this file.

fixes: https://github.com/junegunn/fzf.vim/issues/918