### PR TITLE
[preview] Expand ~-prefixes in preview.sh.

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -11,6 +11,7 @@ fi
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 CENTER=${INPUT[1]}
+FILE=$(eval echo "${FILE}")
 
 if [[ $1 =~ ^[A-Z]:\\ ]]; then
   FILE=$FILE:${INPUT[1]}


### PR DESCRIPTION
Previously, when preview.sh received filenames of the form

    ~/path/to/file.txt

it failed to preview, displaying instead

    File not found ~/path/to/file.txt

That is problematic in general, and specifically results in preview failures when using fzf#vim#history:

    call fzf#vim#history(fzf#vim#with_preview())

If, as often happens, a file in vim's history has a `~`-prefix, it would fail to preview with the above error.

Here, the `~`-prefix is expanded to the value of $HOME inside preview.sh.  The result is that the interface of fzf#vim#history remains unchanged--`~`'s are still displayed--and previews are displayed for paths which are `~`-prefixed.