### PR TITLE
(bugfix) filenames with double-colons will lead to erroneous behaviour

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -641,7 +641,7 @@ endfunction
 " Ag / Rg
 " ------------------------------------------------------------------
 function! s:ag_to_qf(line, has_column)
-  let parts = split(a:line, ':')
+  let parts = split(a:line, '[^:]\zs:\ze[^:]')
   let text = join(parts[(a:has_column ? 3 : 2):], ':')
   let dict = {'filename': &acd ? fnamemodify(parts[0], ':p') : parts[0], 'lnum': parts[1], 'text': text}
   if a:has_column


### PR DESCRIPTION
Opening files with a double-colon results in wrong filename getting used for opening the file.
The fix is pretty naive and static, it replaces all double-colon with another (less-used) character and so far works only for exactly two repeating colons (i tried to make it a regex but it didn't work, i'm a vimscript rookie)