### PR TITLE
Use FZF_PREVIEW_LINES instead of LINES

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -32,7 +32,9 @@ if [ -z "$CENTER" ]; then
   CENTER=0
 fi
 
-if [ -z "$LINES" ]; then
+if [ -n "$FZF_PREVIEW_LINES" ]; then
+  LINES=$FZF_PREVIEW_LINES
+else
   if [ -r /dev/tty ]; then
     LINES=$(stty size < /dev/tty | awk '{print $1}')
   else


### PR DESCRIPTION
since fzf v0.18.0 `FZF_PREVIEW_LINES` is preferred over `LINES`.

See this issue junegunn/fzf/issues/1314 and this commit junegunn/fzf@8dc1377efb140c40c7e121b29d9cedb52ad9ea9f