### PR TITLE
Add `Resume` command

### DIFF
--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -130,6 +130,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:Maps`            | Normal mode mappings
   `:Helptags`        | Help tags [1]
   `:Filetypes`       | File types
+  `:Resume`          | Resume last command (with fzf query if there was one)
  ------------------+-----------------------------------------------------------------------
 
                                                           *g:fzf_command_prefix*

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -61,6 +61,7 @@ call s:defs([
 \'command! -bar -bang BCommits                           call fzf#vim#buffer_commits(<bang>0)',
 \'command! -bar -bang Maps                               call fzf#vim#maps("n", <bang>0)',
 \'command! -bar -bang Filetypes                          call fzf#vim#filetypes(<bang>0)',
+\'command!            Resume                             call fzf#vim#resume()',
 \'command!      -bang -nargs=* History                   call s:history(<q-args>, <bang>0)'])
 
 function! s:history(arg, bang)


### PR DESCRIPTION
### What

A command that opens last used fzf command buffer (with the query).

Example mapping:

```vimscript
nnoremap <leader>u :Resume<cr>
```

### Why

Because I often run the same query. And I am missing `UniteResume`

cc #182 