### PR TITLE
use different bindings at EOL for insert mode completion

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1258,7 +1258,7 @@ function! s:complete_insert(lines)
   if mode() =~ 't'
     call feedkeys('a', 'n')
   else
-    execute "normal! \<esc>la"
+    execute s:eol ? "normal! \<esc>a" : "normal! \<esc>la"
   endif
 endfunction
 


### PR DESCRIPTION
I have `set whichwrap+=l` in my vim config. When fzf finishes an insert mode completion, it executes `<Esc>la`, which moves the cursor to the next line with this setting enabled.
This pull request changes the code to use `<Esc>a` at the end of the line to avoid this behaviour.

I understand that `whichwrap+=l` is not recommended, but this seems like an easy change to enable compatibility with that option.