### PR TITLE
Revert "[GFiles?] include all untracked files (#222)"

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -550,7 +550,7 @@ function! fzf#vim#gitfiles(args, ...)
   " We're trying to access the common sink function that fzf#wrap injects to
   " the options dictionary.
   let wrapped = fzf#wrap({
-  \ 'source':  'git -c color.status=always status --short --untracked-files=all',
+  \ 'source':  'git -c color.status=always status --short',
   \ 'dir':     root,
   \ 'options': ['--ansi', '--multi', '--nth', '2..,..', '--tiebreak=index', '--prompt', 'GitFiles?> ', '--preview', 'sh -c "(git diff --color=always -- {-1} | sed 1,4d; cat {-1}) | head -500"']
   \})


### PR DESCRIPTION
Fix `:GFiles?` for repositories with huge number of untracked files.
Use `git config status.showUntrackedFiles all` to show all files.

This reverts commit 47d4655bd884975fec0b57c572e04a20bdf73a61.