### PR TITLE
Respect BAT_STYLE in bin/preview.sh

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -47,7 +47,7 @@ FIRST=$(($FIRST < 1 ? 1 : $FIRST))
 LAST=$((${FIRST}+${LINES}-1))
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && command -v bat > /dev/null; then
-  bat --style=numbers --color=always --pager=never \
+  bat --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
       --line-range=$FIRST:$LAST --highlight-line=$CENTER "$FILE"
   exit $?
 fi


### PR DESCRIPTION
I use `bin/preview.sh` in my shell script outside of vim. When I'm previewing, I want to also show the filename at the top of the preview window. Luckily, `bat` has already provideded such feature, like using `--style="numbers,header"`.  Although I can add `--style="numbers,header"` to `~/.config/bat/config`, but `bat --style=numbers ...` in `bin/preiew.sh` will win over that. So I propose to append  `FZF_PREVIEW_BAT_OPTIONS` to the command in `bin/preiew.sh`, so anyone who is using bat to preview can pass in extra options to override specified options.

Does this make sense? Thanks.