### PR TITLE
Fix error when passing options to fzf#vim#commits() & fzf#vim#buffer_commits()

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1147,11 +1147,11 @@ function! s:commits(buffer_local, args)
 endfunction
 
 function! fzf#vim#commits(...)
-  return s:commits(0, a:000)
+  return s:commits(0, a:000[1:])
 endfunction
 
 function! fzf#vim#buffer_commits(...)
-  return s:commits(1, a:000)
+  return s:commits(1, a:000[1:])
 endfunction
 
 " ------------------------------------------------------------------


### PR DESCRIPTION
Currently, `fzf#vim#commits()` and `fzf#vim#buffer_commits()` passing `a:000` to `s:commits()`. This makes passing custom options like `{ 'options': ['--layout', 'reverse'] }` to `fzf#vim#commits()` and `fzf#vim#buffer_commits()` will cause following errors:
```
Error detected while processing function vimrc#execute_and_save[2]..fzf#vim#buffer_commits[1]..<SNR>293_commits[44]..<SNR>293_fzf:
line   15:
E715: Dictionary required
line   16:
E712: Argument of extend() must be a List or Dictionary
Error detected while processing function vimrc#execute_and_save[2]..fzf#vim#buffer_commits[1]..<SNR>293_commits[44]..<SNR>293_fzf[18]..<SNR>293_wrap:
line    4:
E715: Dictionary required
line    7:
E715: Dictionary required
Error detected while processing function vimrc#execute_and_save[2]..fzf#vim#buffer_commits[1]..<SNR>293_commits[44]..<SNR>293_fzf[18]..<SNR>293_wrap[12]..fzf#wrap:
line    7:
E605: Exception not caught: Invalid arguments (expected: [name string] [opts dict] [fullscreen boolean])
Error detected while processing function vimrc#execute_and_save[2]..fzf#vim#buffer_commits[1]..<SNR>293_commits[44]..<SNR>293_fzf[18]..<SNR>293_wrap:
line   12:
E171: Missing :endif
```
Passing `a:000[1:]` to `s:commits()` will fix the problem.