### PR TITLE
Fix(preview.sh): Fix Regex that replace tilde in wrong way

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -17,7 +17,7 @@ if [[ $1 =~ ^[A-Z]:\\ ]]; then
   CENTER=${INPUT[2]}
 fi
 
-FILE="${FILE/#\~\//$HOME\/}"
+FILE="${FILE/#\~\//$HOME/}"
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"
   exit 1


### PR DESCRIPTION
The regex is supposed to replace tilde to $HOME.

However the regex used unnecessary escaping, so the replacing was
mistaken.

The path always showed "File not found" in preview window.

```bash
FILE='~/work/test.sh'

FILE_before_fix="${FILE/#\~\//$HOME\/}"
echo $FILE_before_fix
# FILE_before_fix = /Users/user\/work/test.sh
# unnecessary escaping has shown up.

FILE_after_fix="${FILE/#\~\//$HOME/}"
echo $FILE_after_fix
# FILE_after_fix = /Users/user/work/test.sh
# This works right.
```