### PR TITLE
Fix(vim.vim): Error calling Files when ripgrep is FZF_DEFAULT_COMMAND

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -323,7 +323,16 @@ function! fzf#vim#files(dir, ...)
 
   let args.options = ['-m', '--prompt', strwidth(dir) < &columns / 2 - 20 ? dir : '> ']
   call s:merge_opts(args, get(g:, 'fzf_files_options', []))
-  return s:fzf('files', args, a:000)
+
+  try
+    let prev_default_command = $FZF_DEFAULT_COMMAND
+    if !empty(matchstr(prev_default_command, '^rg'))
+      let $FZF_DEFAULT_COMMAND = 'rg --files'
+    endif
+    return s:fzf('files', args, a:000)
+  finally
+    let $FZF_DEFAULT_COMMAND = prev_default_command
+  endtry
 endfunction
 
 " ------------------------------------------------------------------


### PR DESCRIPTION
related to https://github.com/junegunn/fzf.vim/issues/657 .

When users set FZF_DEFAULT_COMMAND as `rg` or `rg ~~~`, `Files` command fails.  It is because it calls raw `fzf` which is same as FZF_DEFAULT_COMMAND, but command is supposed to be 'rg --files' to look up files under current directory.

I came up with thinking that I need to fix fzf side, but [`fzf#vim#grep` has same approach](https://github.com/junegunn/fzf.vim/blob/master/autoload/fzf/vim.vim#L737-L743) replacing FZF_DEFAULT_COMMAND, so I make PR in fzf.vim side.