### PR TITLE
Fix preview bin directory for git bash

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -28,8 +28,6 @@ set cpo&vim
 " Common
 " ------------------------------------------------------------------
 
-" 'preview': '/mnt/c/Users/ladev/vimfiles/pack/default/start/fzf.vim/bin/preview.sh',
-
 let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -28,6 +28,8 @@ set cpo&vim
 " Common
 " ------------------------------------------------------------------
 
+" 'preview': '/mnt/c/Users/ladev/vimfiles/pack/default/start/fzf.vim/bin/preview.sh',
+
 let s:is_win = has('win32') || has('win64')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:h:h:h').'/bin/'
@@ -41,7 +43,8 @@ if s:is_win
   else
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
   endif
-  let s:bin.preview = 'bash '.escape(s:bin.preview, '\')
+    let git_bash_bin = 'bash /mnt/'.substitute(s:bin.preview, '\([A-Z]\):', '\L\1\e', '')
+    let s:bin.preview = substitute(git_bash_bin, '\', '/', 'g')
 endif
 
 let s:wide = 120


### PR DESCRIPTION
Hey thanks for the great work on fzf.

This PR is supposed to fix https://github.com/junegunn/fzf.vim/issues/988.
If you have suggestions, i can edit the code and test on my Windows computer.

The preview bin is not found on window using git for windows.
The issue is that git bash is using a unix like path architecture
(disk mounted in /mnt dir).

The fix replace, path disk name with unix path to disk style, and `\`
with `/`.