### PR TITLE
Make `s:get_git_root()` public (or rather semi-private) for user extension?

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -543,13 +543,13 @@ endfunction
 " GFiles[?]
 " ------------------------------------------------------------------
 
-function! s:get_git_root()
+function! fzf#vim#_get_git_root()
   let root = split(system('git rev-parse --show-toplevel'), '\n')[0]
   return v:shell_error ? '' : root
 endfunction
 
 function! fzf#vim#gitfiles(args, ...)
-  let root = s:get_git_root()
+  let root = fzf#vim#_get_git_root()
   if empty(root)
     return s:warn('Not in git repo')
   endif
@@ -1117,7 +1117,7 @@ function! s:commits_sink(lines)
 endfunction
 
 function! s:commits(buffer_local, args)
-  let s:git_root = s:get_git_root()
+  let s:git_root = fzf#vim#_get_git_root()
   if empty(s:git_root)
     return s:warn('Not in git repository')
   endif


### PR DESCRIPTION
I'm working on a few fzf extensions that need to reference the git root, and am having to copy your `s:get_git_root()` function in all of them.  What about making this one public as `_get_git_root()` (or rather semi-private, and obviously undocumented) for user extension?

PS. I know when users like me extend this stuff, it's without warranty 😂, but so many of your functions are script-local, it can be hard to extend at times.