### PR TITLE
fix: Handle absolute windows paths in Grep/Ag/Ripgrep sink process

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -669,11 +669,11 @@ endfunction
 " Ag / Rg
 " ------------------------------------------------------------------
 function! s:ag_to_qf(line, has_column)
-  let parts = split(a:line, '[^:]\zs:\ze[^:]')
-  let text = join(parts[(a:has_column ? 3 : 2):], ':')
-  let dict = {'filename': &acd ? fnamemodify(parts[0], ':p') : parts[0], 'lnum': parts[1], 'text': text}
+  let parts = matchlist(a:line, '\(.*\):\(\d\+\):\(\d\+\):\(.*\)')
+  let text = parts[4]
+  let dict = {'filename': &acd ? fnamemodify(parts[1], ':p') : parts[1], 'lnum': parts[2], 'text': parts[4]}
   if a:has_column
-    let dict.col = parts[2]
+    let dict.col = parts[3]
   endif
   return dict
 endfunction

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -669,8 +669,7 @@ endfunction
 " Ag / Rg
 " ------------------------------------------------------------------
 function! s:ag_to_qf(line, has_column)
-  let parts = matchlist(a:line, '\(.*\):\(\d\+\):\(\d\+\):\(.*\)')
-  let text = parts[4]
+  let parts = matchlist(a:line, '\(.\{-}\):\(\d\+\)\%(:\(\d\+\)\)\?\%(:\(.*\)\)\?')
   let dict = {'filename': &acd ? fnamemodify(parts[1], ':p') : parts[1], 'lnum': parts[2], 'text': parts[4]}
   if a:has_column
     let dict.col = parts[3]


### PR DESCRIPTION
Function `ag_to_qf` is used to parse line produced by Grep, Ag or
Ripgrep. Implementation in quesition split it using regexp that doesn't
work for windows absolut paths.

A better approach is to use `matchlist` function.

Fixes #1037