### PR TITLE
Fix regex to extract fzf_version

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -72,7 +72,7 @@ function! s:check_requirements()
     throw "fzf#exec function not found. You need to upgrade Vim plugin from the main fzf repository ('junegunn/fzf')"
   endif
   let exec = fzf#exec()
-  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9.]*')
+  let fzf_version = matchstr(systemlist(exec .. ' --version')[0], '[0-9.]\+')
 
   if s:version_requirement(fzf_version, s:min_version)
     let s:checked = 1


### PR DESCRIPTION
I got an error while version check.

`E605: Exception not caught: You need to upgrade fzf. Found:  (/Users/peter_br_lu/.fzf/bin/fzf). Required: 0.23.0 or above.`

My fzf version from cli:
```
⟩ /Users/peter_br_lu/.fzf/bin/fzf --version
0.23.1 (fc7630a)
```
and try to fix....