### PR TITLE
option to skip asking for tag generation

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -898,6 +898,9 @@ function! fzf#vim#tags(query, ...)
     return s:warn('Tags command requires perl')
   endif
   if empty(tagfiles())
+    if get(g:, 'fzf_tags_noaskgen')
+      return s:warn('No tags found')
+    endif
     call inputsave()
     echohl WarningMsg
     let gen = input('tags not found. Generate? (y/N) ')

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -204,6 +204,9 @@ below.
     " [Tags] Command to generate tags file
     let g:fzf_tags_command = 'ctags -R'
 
+		" [Tags] Skip asking for tag generation
+		let g:fzf_tags_noaskgen = 1
+
     " [Commands] --expect expression for directly executing the command
     let g:fzf_commands_expect = 'alt-enter,ctrl-x'
 <


### PR DESCRIPTION
This is for an option to skip the vim prompt that asks for generating tags in the case where this is never wanted.