### PR TITLE
Incorporate batcat name

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -39,8 +39,15 @@ if [ -z "$CENTER" ]; then
   CENTER=0
 fi
 
-if [ -z "$FZF_PREVIEW_COMMAND" ] && command -v bat > /dev/null; then
-  bat --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
+# Sometimes bat is installed as batcat.
+if command -v bat > /dev/null; then
+    BATNAME="bat"
+elif command -v batcat > /dev/null; then
+    BATNAME="batcat"
+fi
+
+if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
+  ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
       --highlight-line=$CENTER "$FILE"
   exit $?
 fi

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -40,10 +40,10 @@ if [ -z "$CENTER" ]; then
 fi
 
 # Sometimes bat is installed as batcat.
-if command -v bat > /dev/null; then
-    BATNAME="bat"
-elif command -v batcat > /dev/null; then
-    BATNAME="batcat"
+if command -v batcat > /dev/null; then
+  BATNAME="batcat"
+elif command -v bat > /dev/null; then
+  BATNAME="bat"
 fi
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then


### PR DESCRIPTION
Seemed to me this is neater then changing it manually, or having to create a symlink, which isn't necessarily possible when user has installed the alternative bat package.

Additionally/alternatively a vimrc option could also be created to define path/name of executable of bat.