### PR TITLE
[fzf#vim#gitfiles] Add arg for changing root

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,32 +59,34 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 Commands
 --------
 
-| Command           | List                                                                    |
-| ---               | ---                                                                     |
-| `:Files [PATH]`   | Files (runs `$FZF_DEFAULT_COMMAND` if defined)                          |
-| `:GFiles [OPTS]`  | Git files (`git ls-files`)                                              |
-| `:GFiles?`        | Git files (`git status`)                                                |
-| `:Buffers`        | Open buffers                                                            |
-| `:Colors`         | Color schemes                                                           |
-| `:Ag [PATTERN]`   | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all) |
-| `:Rg [PATTERN]`   | [rg][rg] search result (`ALT-A` to select all, `ALT-D` to deselect all) |
-| `:Lines [QUERY]`  | Lines in loaded buffers                                                 |
-| `:BLines [QUERY]` | Lines in the current buffer                                             |
-| `:Tags [QUERY]`   | Tags in the project (`ctags -R`)                                        |
-| `:BTags [QUERY]`  | Tags in the current buffer                                              |
-| `:Marks`          | Marks                                                                   |
-| `:Windows`        | Windows                                                                 |
-| `:Locate PATTERN` | `locate` command output                                                 |
-| `:History`        | `v:oldfiles` and open buffers                                           |
-| `:History:`       | Command history                                                         |
-| `:History/`       | Search history                                                          |
-| `:Snippets`       | Snippets ([UltiSnips][us])                                              |
-| `:Commits`        | Git commits (requires [fugitive.vim][f])                                |
-| `:BCommits`       | Git commits for the current buffer                                      |
-| `:Commands`       | Commands                                                                |
-| `:Maps`           | Normal mode mappings                                                    |
-| `:Helptags`       | Help tags <sup id="a1">[1](#helptags)</sup>                             |
-| `:Filetypes`      | File types
+| Command                     | List                                                                    |
+| ---                         | ---                                                                     |
+| `:Files [PATH]`             | Files (runs `$FZF_DEFAULT_COMMAND` if defined)                          |
+| `:GFiles [OPTS]`            | Git files (`git ls-files`) in the git root directory                    |
+| `:GFiles?`                  | Git files (`git status`)  in the git root directory                     |
+| `:GFilesCurrentDir [OPTS]`  | Git files (`git ls-files`) in the current directory                     |
+| `:GFilesCurrentDir?`        | Git files (`git status`) in the current directory                       |
+| `:Buffers`                  | Open buffers                                                            |
+| `:Colors`                   | Color schemes                                                           |
+| `:Ag [PATTERN]`             | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all) |
+| `:Rg [PATTERN]`             | [rg][rg] search result (`ALT-A` to select all, `ALT-D` to deselect all) |
+| `:Lines [QUERY]`            | Lines in loaded buffers                                                 |
+| `:BLines [QUERY]`           | Lines in the current buffer                                             |
+| `:Tags [QUERY]`             | Tags in the project (`ctags -R`)                                        |
+| `:BTags [QUERY]`            | Tags in the current buffer                                              |
+| `:Marks`                    | Marks                                                                   |
+| `:Windows`                  | Windows                                                                 |
+| `:Locate PATTERN`           | `locate` command output                                                 |
+| `:History`                  | `v:oldfiles` and open buffers                                           |
+| `:History:`                 | Command history                                                         |
+| `:History/`                 | Search history                                                          |
+| `:Snippets`                 | Snippets ([UltiSnips][us])                                              |
+| `:Commits`                  | Git commits (requires [fugitive.vim][f])                                |
+| `:BCommits`                 | Git commits for the current buffer                                      |
+| `:Commands`                 | Commands                                                                |
+| `:Maps`                     | Normal mode mappings                                                    |
+| `:Helptags`                 | Help tags <sup id="a1">[1](#helptags)</sup>                             |
+| `:Filetypes`                | File types
 
 - Most commands support `CTRL-T` / `CTRL-X` / `CTRL-V` key
   bindings to open in a new tab, a new split, or in a new vertical split
@@ -155,15 +157,15 @@ let g:fzf_commands_expect = 'alt-enter,ctrl-x'
 Each command in fzf.vim is backed by a Vim function. You can override
 a command or define a variation of it by calling its corresponding function.
 
-| Command   | Vim function                                                               |
-| ---       | ---                                                                        |
-| `Files`   | `fzf#vim#files(dir, [spec dict], [fullscreen bool])`                       |
-| `GFiles`  | `fzf#vim#gitfiles(git_options, [spec dict], [fullscreen bool])`            |
-| `GFiles?` | `fzf#vim#gitfiles('?', [spec dict], [fullscreen bool])`                    |
-| `Buffers` | `fzf#vim#buffers([spec dict], [fullscreen bool])`                          |
-| `Colors`  | `fzf#vim#colors([spec dict], [fullscreen bool])`                           |
-| `Rg`      | `fzf#vim#grep(command, [has_column bool], [spec dict], [fullscreen bool])` |
-| ...       | ...                                                                        |
+| Command   | Vim function                                                                     |
+| ---       | ---                                                                              |
+| `Files`   | `fzf#vim#files(dir, [spec dict], [fullscreen bool])`                             |
+| `GFiles`  | `fzf#vim#gitfiles(git_options, use_current_dir, [spec dict], [fullscreen bool])` |
+| `GFiles?` | `fzf#vim#gitfiles('?', use_current_dir, [spec dict], [fullscreen bool])`         |
+| `Buffers` | `fzf#vim#buffers([spec dict], [fullscreen bool])`                                |
+| `Colors`  | `fzf#vim#colors([spec dict], [fullscreen bool])`                                 |
+| `Rg`      | `fzf#vim#grep(command, [has_column bool], [spec dict], [fullscreen bool])`       |
+| ...       | ...                                                                              |
 
 (We can see that the last two optional arguments of each function are
 identical. They are directly passed to `fzf#wrap` function. If you haven't

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -607,7 +607,7 @@ function! s:get_git_root()
   return v:shell_error ? '' : root
 endfunction
 
-function! fzf#vim#gitfiles(args, ...)
+function! fzf#vim#gitfiles(args, use_current_dir, ...)
   let root = s:get_git_root()
   if empty(root)
     return s:warn('Not in git repo')
@@ -615,7 +615,7 @@ function! fzf#vim#gitfiles(args, ...)
   if a:args != '?'
     return s:fzf('gfiles', {
     \ 'source':  'git ls-files '.a:args.(s:is_win ? '' : ' | uniq'),
-    \ 'dir':     root,
+    \ 'dir':     a:use_current_dir ? getcwd() : root,
     \ 'options': '-m --prompt "GitFiles> "'
     \}, a:000)
   endif
@@ -625,7 +625,7 @@ function! fzf#vim#gitfiles(args, ...)
   " the options dictionary.
   let wrapped = fzf#wrap({
   \ 'source':  'git -c color.status=always status --short --untracked-files=all',
-  \ 'dir':     root,
+  \ 'dir':     a:use_current_dir ? getcwd() : root,
   \ 'options': ['--ansi', '--multi', '--nth', '2..,..', '--tiebreak=index', '--prompt', 'GitFiles?> ', '--preview', 'sh -c "(git diff --color=always -- {-1} | sed 1,4d; cat {-1}) | head -1000"']
   \})
   call s:remove_layout(wrapped)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -54,8 +54,10 @@ endfunction
 
 call s:defs([
 \'command!      -bang -nargs=? -complete=dir Files       call fzf#vim#files(<q-args>, s:p(), <bang>0)',
-\'command!      -bang -nargs=? GitFiles                  call fzf#vim#gitfiles(<q-args>, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
-\'command!      -bang -nargs=? GFiles                    call fzf#vim#gitfiles(<q-args>, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
+\'command!      -bang -nargs=? GitFiles                  call fzf#vim#gitfiles(<q-args>, 0, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
+\'command!      -bang -nargs=? GFiles                    call fzf#vim#gitfiles(<q-args>, 0, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
+\'command!      -bang -nargs=? GitFilesCurrentDir        call fzf#vim#gitfiles(<q-args>, 1, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
+\'command!      -bang -nargs=? GFilesCurrentDir          call fzf#vim#gitfiles(<q-args>, 1, s:p(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
 \'command! -bar -bang -nargs=? -complete=buffer Buffers  call fzf#vim#buffers(<q-args>, s:p({ "placeholder": "{1}" }), <bang>0)',
 \'command!      -bang -nargs=* Lines                     call fzf#vim#lines(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BLines                    call fzf#vim#buffer_lines(<q-args>, <bang>0)',
@@ -159,4 +161,3 @@ onoremap <silent> <plug>(fzf-maps-o) <c-c>:<c-u>call fzf#vim#maps('o', 0)<cr>
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-


### PR DESCRIPTION
Hi,

First of all thank you for creating `fzf` its completely changed the way I use vim and the command line.

In my current role, I am stuck working on a mono repo and `:GFiles` ends up grabbing all files from all the projects in the mono repo (which is not that ideal).

This change adds a new command `GFilesCurrentDir` which works essentially the same as `:GFiles` but using the current directory as the `dir` for the `fzf` call instead of the git project root. The end results (for mono repos) is that `:GFilesCurrentDir` in a project directory works the same as `:GFiles` in a regular git repo