### PR TITLE
Disabled automatic column option for Ag.

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -767,7 +767,7 @@ function! fzf#vim#ag_raw(command_suffix, ...)
   if !executable('ag')
     return s:warn('ag is not found')
   endif
-  return call('fzf#vim#grep', extend(['ag --nogroup --column --color '.a:command_suffix, 1], a:000))
+  return call('fzf#vim#grep', extend(['ag --nogroup --color '.a:command_suffix, 1], a:000))
 endfunction
 
 " command (string), has_column (0/1), [options (dict)], [fullscreen (0/1)]


### PR DESCRIPTION
The build in grep function doesn't automatically show the column number, and therefore the Rg and GGrep examples in the README don't either. But Ag does. This branch removes this default option.

Not sure if there are any backwards compatibility problems, but don't see why it should and for me it works fine.