### PR TITLE
Allow bat --color to be user configurable

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -47,8 +47,7 @@ elif command -v bat > /dev/null; then
 fi
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
-  ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
-      --highlight-line=$CENTER "$FILE"
+  ${BATNAME} --style="${BAT_STYLE:-numbers}" --pager=never --highlight-line=$CENTER "$FILE"
   exit $?
 fi
 


### PR DESCRIPTION
This PR allows the `--color` option for `bat` to be defined by the user, so it can be disabled. `bat` supports a [configuration file](https://github.com/sharkdp/bat#configuration-file) that is automatically picked up if present. The default behavior of `bat` is to display text with colors, so this would not break backwards compatibility by removing the explicit `--color=always` flag.