### PR TITLE
Fix :Tags returning no results when the current buffer is a Neovim terminal

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -921,7 +921,7 @@ function! fzf#vim#tags(query, ...)
     endif
   endif
 
-  let tagfiles = tagfiles()
+  let tagfiles = map(tagfiles(), 'substitute(v:val, "^term://", "", "")')
   let v2_limit = 1024 * 1024 * 200
   for tagfile in tagfiles
     let v2_limit -= getfsize(tagfile)


### PR DESCRIPTION
## Problem

`tagfiles()` returns paths that are prefixed with `term://` when the current buffer is a Neovim terminal. But those are not valid paths, so ctags ignores them, which means that `:Tags` / `fzf#vim#tags` returns no results.

## Solution

Fix the problem by removing the `term://` prefix from these paths.