### PR TITLE
Fix file preview on Windows

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -23,6 +23,7 @@ fi
 CENTER=${CENTER/[^0-9]*/}
 
 FILE="${FILE/#\~\//$HOME/}"
+FILE="${FILE//\\\\/\/}"
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"
   exit 1


### PR DESCRIPTION
On Windows, whenever I tried to use any of the commands to pick files, in the preview I would get an error saying that the target file was not found, but *only* when the target file was in a directory. If this sounds confusing, I'm providing screenshots below:

![outer](https://user-images.githubusercontent.com/28014843/100403195-7b61d400-305e-11eb-9093-585f50c551d2.png)
_(file located in the project's root)_

![inner](https://user-images.githubusercontent.com/28014843/100403218-93395800-305e-11eb-9565-d8f492a68907.png)
_(file located in a subdirectory)_

I figured somehow a double-backslash was being used as a path separator, on Windows. I looked at the `preview.sh` script and replaced all pairs of backslashes in `$FILE` with a single forward slash, which Windows also accepts.

I repointed the plugin to my local repository and it seems to be working.
Unfortunately I don't have a Unix system at hand at the moment to test it on but _it shouldn't™_ break anything there.


Thanks for your work on `fzf.vim`! I literally wouldn't use Vim as my code editor without it 🙂 