### PR TITLE
set jump if the target is in the current file

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -305,6 +305,7 @@ endfunction
 
 function! s:open(cmd, target)
   if stridx('edit', a:cmd) == 0 && fnamemodify(a:target, ':p') ==# expand('%:p')
+    normal! m'
     return
   endif
   execute a:cmd s:escape(a:target)


### PR DESCRIPTION
Adding a record to the jump list allows to go back to the cursor position before jump with CTRL-O.