### PR TITLE
[Snippets] Fix entering insert mode and handling of word under cursor

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -943,8 +943,9 @@ endfunction
 function! s:inject_snippet(line)
   let ve = &ve
   set ve=onemore
+  let del = col('.') > 1 && getline('.')[0 : col('.')-2] =~ "\\S$" ? "\<c-w>" : ""
   let snip = split(a:line, "\t")[0]
-  execute 'normal! a'.s:strip(snip)
+  execute 'normal! i'.del.s:strip(snip)
   execute 'normal! l'
   call UltiSnips#ExpandSnippet()
   let &ve = ve

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -941,8 +941,13 @@ endfunction
 " Snippets (UltiSnips)
 " ------------------------------------------------------------------
 function! s:inject_snippet(line)
+  let ve = &ve
+  set ve=onemore
   let snip = split(a:line, "\t")[0]
-  execute 'normal! a'.s:strip(snip)."\<c-r>=UltiSnips#ExpandSnippet()\<cr>"
+  execute 'normal! a'.s:strip(snip)
+  execute 'normal! l'
+  call UltiSnips#ExpandSnippet()
+  let &ve = ve
 endfunction
 
 function! fzf#vim#snippets(...)


### PR DESCRIPTION
Two fixes for #796

[Snippets] Fix UltiSnips not being able to enter insert mode

UltiSnips snippets have so called tabstops or placeholders that are to be filled in by the user, so after expanding a snippet the cursor is moved to the first such tabstop and vim enters insert mode (or, if there's a default value, select mode).

But this doesn't work with fzf's :Snippets, because UltiSnips uses :startinsert which doesn't work from :normal. Fix this by calling UltiSnips#ExpandSnippet directly (unfortunately needs a virtualedit hack to position the cursor after the snippet name).

---

[Snippets] Fix when there is word under cursor

UltiSnips#SnippetsInCurrentScope uses the word under cursor, if any, to filter candidate snippets. To make it usable, however, fzf's :Snippets must replace the word instead of appending to it, otherwise the subsequent expansion fails.

Also, use 'i' instead of 'a', to make mappings such as

	inoremap <silent> <C-_> <C-\><C-O>:Snippets<CR>

feel natural. This will break workflow for people who used to manually exit insert mode in the middle of a line and then invoke :Snippets, but I'd hazard a guess there aren't many of them as this workflow was already somewhat broken by the first bug.

---

Fixes: https://github.com/junegunn/fzf.vim/issues/796