### PR TITLE
make :GFiles work with "unusual" filenames

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -618,9 +618,9 @@ function! fzf#vim#gitfiles(args, ...)
   let prefix = 'git -C ' . fzf#shellescape(root) . ' '
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  prefix . 'ls-files '.a:args.(s:is_win ? '' : ' | uniq'),
+    \ 'source':  prefix . 'ls-files -z'.a:args.(s:is_win ? '' : ' | uniq'),
     \ 'dir':     root,
-    \ 'options': '-m --prompt "GitFiles> "'
+    \ 'options': '-m --read0 --prompt "GitFiles> "'
     \}, a:000)
   endif
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -618,7 +618,7 @@ function! fzf#vim#gitfiles(args, ...)
   let prefix = 'git -C ' . fzf#shellescape(root) . ' '
   if a:args != '?'
     return s:fzf('gfiles', {
-    \ 'source':  prefix . 'ls-files -z'.a:args.(s:is_win ? '' : ' | uniq'),
+    \ 'source':  prefix . 'ls-files -z --deduplicate',
     \ 'dir':     root,
     \ 'options': '-m --read0 --prompt "GitFiles> "'
     \}, a:000)


### PR DESCRIPTION
git ls-files quotes file names containing "unusual" (non-ASCII?) characters by default, breaking :GFiles