### PR TITLE
Add Tselect command to filter matching tags

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -943,6 +943,49 @@ function! fzf#vim#tags(query, ...)
 endfunction
 
 " ------------------------------------------------------------------
+" Tselect
+" ------------------------------------------------------------------
+function! s:tselect_sink(query, lines)
+  if len(a:lines) < 2
+    return
+  endif
+  let cmd = s:action_for(a:lines[0], '')
+  let count = split(a:lines[1])[0]
+  if !empty(cmd)
+    execute cmd
+  endif
+  execute count . 'tag' a:query
+endfunction
+
+function! fzf#vim#tselect(query, ...)
+  let stack = gettagstack()
+  let tagstack_head = stack.length != 0 ? stack.items[-1].tagname : ""
+  let query = empty(a:query) ? tagstack_head : a:query
+  if empty(query)
+    echohl Error
+    echo "E73: tag stack empty"
+    echohl None
+    return
+  else
+
+  let tags = map(taglist('^' . query . '$', expand('%:p')), {i, v ->
+  \ [i + 1, get(v, 'filename', ''), get(v, 'class', ''), get(v, 'cmd', '')]})
+
+  let source = map(s:align_lists(tags), 'join(v:val, " ")')
+  if empty(source)
+    echohl Error
+    echo "E426: tag not found: " . query
+    echohl None
+    return
+  endif
+
+  return s:fzf('tselect', {
+  \ 'source':  source,
+  \ 'sink*':   function('s:tselect_sink', [query]),
+  \ 'options': extend([], ['--ansi', '--no-sort', '--tiebreak=index', '--prompt', 'Tselect> '])}, a:000)
+endfunction
+
+" ------------------------------------------------------------------
 " Snippets (UltiSnips)
 " ------------------------------------------------------------------
 function! s:inject_snippet(line)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -107,8 +107,8 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
 
-    *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:Lines* *:BLines* *:Tags* *:BTags* *:Marks*
-        *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
+  *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:Lines* *:BLines* *:Tags* *:BTags* *:Tselect*
+ *:Marks* *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
                                                           *:Helptags* *:Filetypes*
 
  ------------------+-----------------------------------------------------------------------
@@ -125,6 +125,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:BLines [QUERY]`  | Lines in the current buffer
   `:Tags [QUERY]`    | Tags in the project ( `ctags -R` )
   `:BTags [QUERY]`   | Tags in the current buffer
+  `:Tselect [QUERY]` | Tags matching the query (or top of tagstack if QUERY is unspecified)
   `:Marks`           | Marks
   `:Windows`         | Windows
   `:Locate PATTERN`  |  `locate`  command output

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -70,6 +70,7 @@ call s:defs([
 \'command!      -bang -nargs=* Rg                        call fzf#vim#grep("rg --column --line-number --no-heading --color=always --smart-case -- ".shellescape(<q-args>), 1, s:p(), <bang>0)',
 \'command!      -bang -nargs=* Tags                      call fzf#vim#tags(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BTags                     call fzf#vim#buffer_tags(<q-args>, s:p({ "placeholder": "{2}:{3}" }), <bang>0)',
+\'command!      -bang -nargs=* -complete=tag Tselect     call fzf#vim#tselect(<q-args>, <bang>0)',
 \'command! -bar -bang Snippets                           call fzf#vim#snippets(<bang>0)',
 \'command! -bar -bang Commands                           call fzf#vim#commands(<bang>0)',
 \'command! -bar -bang Marks                              call fzf#vim#marks(<bang>0)',


### PR DESCRIPTION
This commit adds a command roughly equivalent to :tselect.

The use can now call Tselect with an optional query. If a query
is specified, all matches for that query are looked up and loaded
for filtering into an fzf window. If no query is specified, the top
tag on the tagstack is used (just like tselect)

This commit borrows some code from https://github.com/zackhsi/fzf-tags