### PR TITLE
Preview support for MS Windows (WSL and Git bash) - Fixes #1212

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -156,10 +156,8 @@ function! fzf#vim#with_preview(...)
     if empty($MSWINHOME)
       let $MSWINHOME = $HOME
     endif
-    if is_wsl_bash
-      if $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
-        let $WSLENV = 'MSWINHOME/u:'.$WSLENV
-      endif
+    if is_wsl_bash && $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
+      let $WSLENV = 'MSWINHOME/u:'.$WSLENV
     endif
     let preview_cmd = 'bash '.(is_wsl_bash
     \ ? substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -153,10 +153,10 @@ function! fzf#vim#with_preview(...)
   endif
   if s:is_win
     let is_wsl_bash = exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$'
+    if empty($MSWINHOME)
+      let $MSWINHOME = $HOME
+    endif
     if is_wsl_bash
-      if empty($MSWINHOME)
-        let $MSWINHOME = $HOME
-      endif
       if $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
         let $WSLENV = 'MSWINHOME/u:'.$WSLENV
       endif

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -153,6 +153,14 @@ function! fzf#vim#with_preview(...)
   endif
   if s:is_win
     let is_wsl_bash = exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$'
+    if is_wsl_bash
+      if empty($MSWINHOME)
+        let $MSWINHOME = $HOME
+      endif
+      if $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
+        let $WSLENV = 'MSWINHOME/u:'.$WSLENV
+      endif
+    endif
     let preview_cmd = 'bash '.(is_wsl_bash
     \ ? substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')
     \ : escape(s:bin.preview, '\'))

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -12,7 +12,7 @@ IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 CENTER=${INPUT[1]}
 
-if [[ $1 =~ ^[A-Z]:\\ ]]; then
+if [[ $1 =~ ^[A-Za-z]:\\ ]]; then
   FILE=$FILE:${INPUT[1]}
   CENTER=${INPUT[2]}
 fi
@@ -23,15 +23,17 @@ fi
 CENTER=${CENTER/[^0-9]*/}
 
 #MS Win support
-if [ -z "$MSWINHOME" ]; then
-  MSWINHOME="$HOMEDRIVE$HOMEPATH"
-fi
-if grep -qEi "(Microsoft|WSL)" /proc/version &> /dev/null ; then
-  MSWINHOME="${MSWINHOME//\\/\\\\}"
-  FILE="${FILE/#\~\\/$MSWINHOME\\}"
-  FILE=`wslpath -u "$FILE"`
-elif [ ! -z "$MSWINHOME" ]; then
-  FILE="${FILE/#\~\\/$MSWINHOME\\}"
+if [[ $FILE =~ "\\" ]]; then
+  if [ -z "$MSWINHOME" ]; then
+    MSWINHOME="$HOMEDRIVE$HOMEPATH"
+  fi
+  if grep -qEi "(Microsoft|WSL)" /proc/version &> /dev/null ; then
+    MSWINHOME="${MSWINHOME//\\/\\\\}"
+    FILE="${FILE/#\~\\/$MSWINHOME\\}"
+    FILE=`wslpath -u "$FILE"`
+  elif [ ! -z "$MSWINHOME" ]; then
+    FILE="${FILE/#\~\\/$MSWINHOME\\}"
+  fi
 fi
 
 FILE="${FILE/#\~\//$HOME/}"

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -22,6 +22,18 @@ if [[ -n "$CENTER" && ! "$CENTER" =~ ^[0-9] ]]; then
 fi
 CENTER=${CENTER/[^0-9]*/}
 
+#MS Win support
+if [ -z "$MSWINHOME" ]; then
+  MSWINHOME="$HOMEDRIVE$HOMEPATH"
+fi
+if grep -qEi "(Microsoft|WSL)" /proc/version &> /dev/null ; then
+  MSWINHOME="${MSWINHOME//\\/\\\\}"
+  FILE="${FILE/#\~\\/$MSWINHOME\\}"
+  FILE=`wslpath -u "$FILE"`
+elif [ ! -z "$MSWINHOME" ]; then
+  FILE="${FILE/#\~\\/$MSWINHOME\\}"
+fi
+
 FILE="${FILE/#\~\//$HOME/}"
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -22,16 +22,16 @@ if [[ -n "$CENTER" && ! "$CENTER" =~ ^[0-9] ]]; then
 fi
 CENTER=${CENTER/[^0-9]*/}
 
-#MS Win support
-if [[ $FILE =~ "\\" ]]; then
+# MS Win support
+if [[ $FILE =~ '\' ]]; then
   if [ -z "$MSWINHOME" ]; then
     MSWINHOME="$HOMEDRIVE$HOMEPATH"
   fi
   if grep -qEi "(Microsoft|WSL)" /proc/version &> /dev/null ; then
     MSWINHOME="${MSWINHOME//\\/\\\\}"
     FILE="${FILE/#\~\\/$MSWINHOME\\}"
-    FILE=`wslpath -u "$FILE"`
-  elif [ ! -z "$MSWINHOME" ]; then
+    FILE=$(wslpath -u "$FILE")
+  elif [ -n "$MSWINHOME" ]; then
     FILE="${FILE/#\~\\/$MSWINHOME\\}"
   fi
 fi


### PR DESCRIPTION
Fixes #1212 by 
- setting MSWINHOME environment variable (to calculated $HOME from vim)
- exports these to WSL (if needed)
- using MSWINHOME in preview.sh for ~
- translating Windows path to WSL path
