### PR TITLE
using Bat with a custom theme

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -67,7 +67,7 @@ elif command -v bat > /dev/null; then
 fi
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
-  ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
+  ${BATNAME} --theme="GitHub" --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
       --highlight-line=$CENTER "$FILE"
   exit $?
 fi


### PR DESCRIPTION
fixes https://github.com/junegunn/fzf.vim/issues/59

to display the `bat` themes you can use 

`bat --list-themes`

Github theme should be used for light color scheme
The default bat theme is for dark color scheme

I patched my `.vim/plugged/fzf.vim/bin/preview.sh` as showed in the diff

I also added this settings for the light color scheme

```
let g:fzf_colors =
    \ { 'fg':      ['fg', 'Normal'],
    \ 'bg':      ['bg', 'Normal'],
    \ 'hl':      ['fg', 'Comment'],
    \ 'fg+':     ['fg', 'CursorLine', 'CursorColumn', 'Normal'],
    \ 'bg+':     ['bg', 'CursorLine', 'CursorColumn'],
    \ 'hl+':     ['fg', 'Statement'],
    \ 'info':    ['fg', 'PreProc'],
    \ 'border':  ['fg', 'Ignore'],
    \ 'prompt':  ['fg', 'Conditional'],
    \ 'pointer': ['fg', 'Exception'],
    \ 'marker':  ['fg', 'Keyword'],
    \ 'spinner': ['fg', 'Label'],
    \ 'header':  ['fg', 'Comment'] }
```
This pr should include some sort of variable that allow the user to switch the theme from vim settings
Never contributed to vim so don't know how to do this right now :rofl: 
I will update this pr once I know how add this to `fzf.vim`. Thanks :pray: 