### PR TITLE
windows: force LF line-endings when checking out `bin/preview.sh`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/preview.sh eol=lf


### PR DESCRIPTION
When checking out with Git on Windows (installed via Chocolatey: https://chocolatey.org/packages/git), CRLF line endings will cause the preview.sh script to fail to run inside WSL2's bash.  The fix for this seems to be to force the preview.sh script to be checked out with LF line endings.