### PR TITLE
Use nvim if vim not installed

### DIFF
--- a/bin/tagpreview.sh
+++ b/bin/tagpreview.sh
@@ -20,7 +20,14 @@ if [ ! -r "$FILE" ]; then
   exit 1
 fi
 
-CENTER="$(vim -i NONE -u NONE -e -m -s "${FILE}" \
+# If users aren't using vim, they are probably using neovim
+if command -v vim > /dev/null; then
+  VIMNAME="vim"
+elif command -v nvim > /dev/null; then
+  VIMNAME="nvim"
+fi
+
+CENTER="$("${VIMNAME}" -i NONE -u NONE -e -m -s "${FILE}" \
               -c "set nomagic" \
               -c "${EXCMD}" \
               -c 'let l=line(".") | new | put =l | print | qa!')" || return

--- a/bin/tagpreview.sh
+++ b/bin/tagpreview.sh
@@ -25,6 +25,9 @@ if command -v vim > /dev/null; then
   VIMNAME="vim"
 elif command -v nvim > /dev/null; then
   VIMNAME="nvim"
+else
+  echo "Cannot preview tag: vim or nvim unavailable"
+  exit 1
 fi
 
 CENTER="$("${VIMNAME}" -i NONE -u NONE -e -m -s "${FILE}" \


### PR DESCRIPTION
The `tagpreview.sh` script is hardcoded to the `vim` binary. For users that only
have  Neovim installed an error is displayed and no preview is rendered.

This change addresses this by falling back to the `nvim` binary if the `vim`
binary isn't present.

Addresses #1261 