### PR TITLE
[Snippets]Hide normal messages when inserting snippet

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -966,7 +966,7 @@ endfunction
 " ------------------------------------------------------------------
 function! s:inject_snippet(line)
   let snip = split(a:line, "\t")[0]
-  execute 'normal! a'.s:strip(snip)."\<c-r>=UltiSnips#ExpandSnippet()\<cr>"
+  silent execute 'normal! a'.s:strip(snip)."\<c-r>=UltiSnips#ExpandSnippet()\<cr>"
 endfunction
 
 function! fzf#vim#snippets(...)


### PR DESCRIPTION
For better view, hide `=UltiSnips#ExpandSnippet()` message when inserting a snippet successfully. If the function calling does not succeed, the message will be displayed.

Before:
<img width="443" alt="before" src="https://user-images.githubusercontent.com/2589259/115129573-c2566300-a019-11eb-949d-4a787fd2164f.png">

