### PR TITLE
Add Tselect command to filter matching tags

### DIFF
--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -108,8 +108,8 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
 
-    *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:Lines* *:BLines* *:Tags* *:BTags* *:Marks*
-        *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
+  *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:Lines* *:BLines* *:Tags* *:BTags* *:Tselect*
+ *:Marks* *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
                                                           *:Helptags* *:Filetypes*
 
  ------------------+-----------------------------------------------------------------------
@@ -126,6 +126,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:BLines [QUERY]`  | Lines in the current buffer
   `:Tags [QUERY]`    | Tags in the project ( `ctags -R` )
   `:BTags [QUERY]`   | Tags in the current buffer
+  `:Tselect [QUERY]` | Tags matching the query (or top of tagstack if QUERY is unspecified)
   `:Marks`           | Marks
   `:Windows`         | Windows
   `:Locate PATTERN`  |  `locate`  command output

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -70,6 +70,7 @@ call s:defs([
 \'command!      -bang -nargs=* Rg                        call fzf#vim#grep("rg --column --line-number --no-heading --color=always --smart-case -- ".shellescape(<q-args>), 1, s:p(), <bang>0)',
 \'command!      -bang -nargs=* Tags                      call fzf#vim#tags(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BTags                     call fzf#vim#buffer_tags(<q-args>, s:p({ "placeholder": "{2}:{3}" }), <bang>0)',
+\'command!      -bang -nargs=* -complete=tag Tselect     call fzf#vim#tselect(<q-args>, <bang>0)',
 \'command! -bar -bang Snippets                           call fzf#vim#snippets(<bang>0)',
 \'command! -bar -bang Commands                           call fzf#vim#commands(<bang>0)',
 \'command! -bar -bang Marks                              call fzf#vim#marks(<bang>0)',


### PR DESCRIPTION
This commit adds a command roughly equivalent to :tselect.

The use can now call Tselect with an optional query. If a query
is specified, all matches for that query are looked up and loaded
for filtering into an fzf window. If no query is specified, the top
tag on the tagstack is used (just like tselect)

This commit borrows some code from https://github.com/zackhsi/fzf-tags