### PR TITLE
Don't mutate args to fzf#vim#files() (and other)

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -302,6 +302,7 @@ function! s:fzf(name, opts, extra)
     throw 'invalid number of arguments'
   endif
 
+  let extra  = copy(extra)
   let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
   let merged = extend(copy(a:opts), extra)
   call s:merge_opts(merged, eopts)


### PR DESCRIPTION
I tried to add this to my dotfiles:

```vim
let s:fzf_files_opts = {
\ 'window': {'width': 0.6, 'height': 0.6, 'relative': v:false},
\ 'options': ['--layout=reverse', '--info=inline'],
\}

command! -bang -nargs=? -complete=dir Files   call fzf#vim#files(<q-args>, s:fzf_files_opts, <bang>0)
```

Now, probably not the best way to customize FZF, but please bear with me. The intention here is to use `--layout=reverse` to have the input at the top, instead of the bottom. Works the first time I try it, but subsequent tries move it back to the bottom.

The bottom line is that `fzf#vim#files()` ends up mutating its argument when calling `s:fzf`. It gets fixed by making a defensive copy.