### PR TITLE
[[B]Commits] Preserve window view

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1267,10 +1267,18 @@ function! s:given_range(line1, line2)
 endfunction
 
 function! fzf#vim#commits(...) range
+  if exists('b:fzf_winview')
+    call winrestview(b:fzf_winview)
+    unlet b:fzf_winview
+  endif
   return s:commits(s:given_range(a:firstline, a:lastline), 0, a:000)
 endfunction
 
 function! fzf#vim#buffer_commits(...) range
+  if exists('b:fzf_winview')
+    call winrestview(b:fzf_winview)
+    unlet b:fzf_winview
+  endif
   return s:commits(s:given_range(a:firstline, a:lastline), 1, a:000)
 endfunction
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -62,8 +62,8 @@ call s:defs([
 \'command! -bar -bang Marks                              call fzf#vim#marks(<bang>0)',
 \'command! -bar -bang Helptags                           call fzf#vim#helptags(<bang>0)',
 \'command! -bar -bang Windows                            call fzf#vim#windows(<bang>0)',
-\'command! -bar -bang -range=% Commits    <line1>,<line2>call fzf#vim#commits(fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
-\'command! -bar -bang -range=% BCommits   <line1>,<line2>call fzf#vim#buffer_commits(fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
+\'command! -bar -bang -range=% Commits                   let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#commits(fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
+\'command! -bar -bang -range=% BCommits                  let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#buffer_commits(fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
 \'command! -bar -bang Maps                               call fzf#vim#maps("n", <bang>0)',
 \'command! -bar -bang Filetypes                          call fzf#vim#filetypes(<bang>0)',
 \'command!      -bang -nargs=* History                   call s:history(<q-args>, fzf#vim#with_preview(), <bang>0)'])


### PR DESCRIPTION
In 161da95, [B]Commits were changed to range commands with -range=%, now
Vim jumps to the first line when these two commands are called directly
without specifying range.

This fixes it by saving window view in a temporary variable and
restoring it later. Reference: [1].

[1] https://vi.stackexchange.com/a/6037/33583
