### PR TITLE
Add support for nushell

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -173,7 +173,7 @@ function! fzf#vim#with_preview(...)
     \ ? substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')
     \ : escape(s:bin.preview, '\'))
   else
-    let preview_cmd = fzf#shellescape(s:bin.preview)
+    let preview_cmd = 'bash ' . fzf#shellescape(s:bin.preview)
   endif
   if len(placeholder)
     let preview += ['--preview', preview_cmd.' '.placeholder]


### PR DESCRIPTION
Because of a quirk of the nushell syntax, it doesn't allow programs surrounded in quotes to be executed, as they are interpreted as string objects. I fixed this issue by making `bash` call the script.