### PR TITLE
shorten long absolute path on preview

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -43,6 +43,7 @@ if [[ $FILE =~ '\' ]]; then
 fi
 
 FILE="${FILE/#\~\//$HOME/}"
+FILE=$(eval echo $FILE)
 if [ ! -r "$FILE" ]; then
   echo "File not found ${FILE}"
   exit 1


### PR DESCRIPTION
To shorten long path string on preview, user-defined environment variables can be expanded.
Because preview window is narrow, economizing file path width is desirable.
':Rg' command output is short comparatively, because target is relative path from current directory.
To use 'fzf#vim#grep()' for user-defined command that prints long absolute path,
path string that shorten with environment variable would like be available.

if environment variable $MYDIR is `/alpha/beta/gamma`,
and user-command in fzf#vim#grep() prints to standard output as follows.
```
$MYDIR/foo.h:10:2: #include <cstdio>
$MYDIR/bar.h:21:2: #include <iostream>
```
preview.sh can expand equivalently below.
```
/alpha/beta/gamma/foo.h:10:2: #include <cstdio>
/alpha/beta/gamma/bar.h:21:2: #include <iostream>
```

