### PR TITLE
Add the dependencie for the windows users preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 - `Ag` requires [The Silver Searcher (ag)][ag]
 - `Rg` requires [ripgrep (rg)][rg]
 - `Tags` and `Helptags` require Perl
+- Git Unix Tools _**ONLY WINDOWS**_ for fzf preview, install with: 
+`choco install git.install --params "/GitAndUnixToolsOnPath"`
+after that add this line on your vimrc or init.vim 
+`let $PATH = "C:\\Program\ Files\\Git\\usr\\bin;" . $PATH`. _You must have [git bash](https://git-scm.com/) installed for it to work properly_
 
 Commands
 --------


### PR DESCRIPTION
**Problem:**
I use fzf.vim on windows but the preview not work and I´m found a solution and share with you :smile: 

**Contents of the PR:**
This PR add the dependencie the Git Unix Windows Tool with the chocolatey power and git bash, this fix the bug I hope you find useful