### PR TITLE
[preview] Support for ambiwidth=double

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -178,6 +178,9 @@ function! fzf#vim#with_preview(...)
   if len(placeholder)
     let preview += ['--preview', preview_cmd.' '.placeholder]
   end
+  if &ambiwidth ==# 'double'
+    let preview += ['--no-unicode']
+  end
 
   if len(args)
     call extend(preview, ['--bind', join(map(args, 'v:val.":toggle-preview"'), ',')])


### PR DESCRIPTION
Fix #1320
Append fzf argument `--no-unicode` when ambiwidth is `double` to keep the preview window rendering correctly.