### PR TITLE
Ensure bash scripts to always use unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Otherwise on Windows it may cause preview.sh to have CRLF as line endings and fail to preview.