### PR TITLE
Fix preview failing on files with special characters

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -18,7 +18,7 @@ IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 CENTER=${INPUT[1]}
 
-if [[ $1 =~ ^[A-Za-z]:\\ ]]; then
+if [[ "$1" =~ ^[A-Za-z]:\\ ]]; then
   FILE=$FILE:${INPUT[1]}
   CENTER=${INPUT[2]}
 fi
@@ -29,7 +29,7 @@ fi
 CENTER=${CENTER/[^0-9]*/}
 
 # MS Win support
-if [[ $FILE =~ '\' ]]; then
+if [[ "$FILE" =~ '\' ]]; then
   if [ -z "$MSWINHOME" ]; then
     MSWINHOME="$HOMEDRIVE$HOMEPATH"
   fi
@@ -61,12 +61,12 @@ fi
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
   ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
-      --highlight-line=$CENTER "$FILE"
+      --highlight-line=$CENTER -- "$FILE"
   exit $?
 fi
 
 FILE_LENGTH=${#FILE}
-MIME=$(file --dereference --mime "$FILE")
+MIME=$(file --dereference --mime -- "$FILE")
 if [[ "${MIME:FILE_LENGTH}" =~ binary ]]; then
   echo "$MIME"
   exit 0


### PR DESCRIPTION
This fixes the preview script failing when given funky file names such as:
- `--whatever`
- `*`
- `file name`
<img src="https://user-images.githubusercontent.com/920910/136687938-fc3c9dbf-e79f-4c40-82aa-ce6bc44b8089.png" width="300" />