### PR TITLE
[GFiles?] Fix preview on windows (wsl bash + git_install_folder/usr/bash)

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -30,9 +30,7 @@ set cpo&vim
 
 let s:min_version = '0.23.0'
 let s:is_win = has('win32') || has('win64')
-if s:is_win
-  let s:is_wsl_bash = exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$'
-endif
+let s:is_wsl_bash = s:is_win && (exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$')
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:p:h:h:h').'/bin/'
 let s:bin = {

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -43,10 +43,10 @@ if s:is_win
   if has('nvim')
     let s:bin.preview = split(system('for %A in ("'.s:bin.preview.'") do @echo %~sA'), "\n")[0]
   else
-    let s:bin.preview = fnamemodify(s:bin.preview, ':8')
-    if s:is_wsl_bash
-      let s:bin.preview = substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')
-    endif
+    let preview_path = s:is_wsl_bash
+      \ ? substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', '')
+      \ : fnamemodify(s:bin.preview, ':8')
+    let s:bin.preview = substitute(preview_path, '\', '/', 'g')
   endif
 endif
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -30,6 +30,9 @@ set cpo&vim
 
 let s:min_version = '0.23.0'
 let s:is_win = has('win32') || has('win64')
+if s:is_win
+  let s:is_wsl_bash = exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$'
+endif
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:p:h:h:h').'/bin/'
 let s:bin = {
@@ -41,6 +44,9 @@ if s:is_win
     let s:bin.preview = split(system('for %A in ("'.s:bin.preview.'") do @echo %~sA'), "\n")[0]
   else
     let s:bin.preview = fnamemodify(s:bin.preview, ':8')
+    if s:is_wsl_bash
+      let s:bin.preview = substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')
+    endif
   endif
 endif
 
@@ -139,15 +145,14 @@ function! fzf#vim#with_preview(...)
     let preview += ['--preview-window', window]
   endif
   if s:is_win
-    let is_wsl_bash = exepath('bash') =~? 'Windows[/\\]system32[/\\]bash.exe$'
     if empty($MSWINHOME)
       let $MSWINHOME = $HOME
     endif
-    if is_wsl_bash && $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
+    if s:is_wsl_bash && $WSLENV !~# '[:]\?MSWINHOME\(\/[^:]*\)\?\(:\|$\)'
       let $WSLENV = 'MSWINHOME/u:'.$WSLENV
     endif
-    let preview_cmd = 'bash '.(is_wsl_bash
-    \ ? substitute(substitute(s:bin.preview, '^\([A-Z]\):', '/mnt/\L\1', ''), '\', '/', 'g')
+    let preview_cmd = 'bash '.(s:is_wsl_bash
+    \ ? s:bin.preview
     \ : escape(s:bin.preview, '\'))
   else
     let preview_cmd = fzf#shellescape(s:bin.preview)
@@ -621,11 +626,12 @@ function! fzf#vim#gitfiles(args, ...)
   " Here be dragons!
   " We're trying to access the common sink function that fzf#wrap injects to
   " the options dictionary.
+  let bar = s:is_win ? '^|' : '|'
   let preview = printf(
     \ 'bash -c "if [[ {1} =~ M ]]; then %s; else %s {-1}; fi"',
     \ executable('delta')
-      \ ? 'git diff -- {-1} | delta --width $FZF_PREVIEW_COLUMNS --file-style=omit | sed 1d'
-      \ : 'git diff --color=always -- {-1} | sed 1,4d',
+      \ ? 'git diff -- {-1} '.bar.' delta --width $FZF_PREVIEW_COLUMNS --file-style=omit '.bar.' sed 1d'
+      \ : 'git diff --color=always -- {-1} '.bar.' sed 1,4d',
     \ s:bin.preview)
   let wrapped = fzf#wrap({
   \ 'source':  'git -c color.status=always status --short --untracked-files=all',


### PR DESCRIPTION
Hello!

I've been a long time user of vim+`fzf` on Windows.

I have always had an issue with the previews on `GFiles?` on Windows:
![image](https://user-images.githubusercontent.com/48007894/150654905-d1dd3c1e-33ca-4764-b391-906805fe6b43.png)

I figured that:
* the pipes are not properly escaped in my use cases (one computer using `bash` from `wsl` (Windows), another computer using `bash` from the installation directory of `git` (Windows))
* `bash` cannot find the `preview` script if its path has backwards slashes

Today I took the time to make a PR.

I did not see Contribution guidelines so I am opening this PR directly.

Please tell me if you need a ticket, additional information, or anything that could help you with this PR.

Best regards,
Melandel.