### PR TITLE
[[B]Commits] Use --color=always with delta as well

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1230,9 +1230,9 @@ function! s:commits(range, buffer_local, args)
   endif
 
   if !s:is_win && &columns > s:wide
-    let suffix = executable('delta') ? '| delta --width $FZF_PREVIEW_COLUMNS' : '--color=always'
+    let suffix = executable('delta') ? '| delta --width $FZF_PREVIEW_COLUMNS' : ''
     call extend(options.options,
-    \ ['--preview', 'echo {} | grep -o "[a-f0-9]\{7,\}" | head -1 | xargs git show --format=format: ' . suffix])
+    \ ['--preview', 'echo {} | grep -o "[a-f0-9]\{7,\}" | head -1 | xargs git show --format=format: --color=always ' . suffix])
   endif
 
   return s:fzf(a:buffer_local ? 'bcommits' : 'commits', options, a:args)


### PR DESCRIPTION
With some delta configurations (e.g. color-only = true, diff-highlight =
true), delta doesn't add its own coloring and keeps that from git diff,
and thus we need to turn that on.

Additionally, delta doesn't do its own detection of moved lines and
relies on git diff's colorMoved, which also needs enabling of colors.