### PR TITLE
[Commands] Fix hit-enter/more-prompt with terminal buffer fzf

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -989,8 +989,7 @@ function! s:command_sink(lines)
   if empty(a:lines[0])
     call feedkeys(':'.cmd.(a:lines[1][0] == '!' ? '' : ' '), 'n')
   else
-    call histadd(':', cmd)
-    execute cmd
+    call feedkeys(':'.cmd."\<cr>", 'n')
   endif
 endfunction
 


### PR DESCRIPTION
Since https://github.com/junegunn/fzf//commit/85ae7459103c3aeef39383d8c8a4fbbdb9fb5f64,
fzf opens in a terminal buffer (in my setup) and that breaks commands
that end up showing the hit-enter or more prompt, such as :scriptnames
or :ALEInfo. No idea why those commands break (I tried to diagnose this
but gave up unfortunately), but executing them using feedkeys fixes
this.