### PR TITLE
[fzf#vim#complete#word]: respect dictionary option

### DIFF
--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -47,9 +47,9 @@ else
 endif
 
 function! fzf#vim#complete#word(...)
-  let sources = empty(&dictionary) ? '/usr/share/dict/words' : substitute(&dictionary, ',', ' ', 'g')
+  let sources = empty(&dictionary) ? ['/usr/share/dict/words'] : split(&dictionary, ',')
   return fzf#vim#complete(s:extend({
-    \ 'source': 'cat ' . sources},
+    \ 'source': 'cat ' . join(map(sources, 'shellescape(v:val)'))},
     \ get(a:000, 0, fzf#wrap())))
 endfunction
 

--- a/autoload/fzf/vim/complete.vim
+++ b/autoload/fzf/vim/complete.vim
@@ -47,8 +47,9 @@ else
 endif
 
 function! fzf#vim#complete#word(...)
+  let sources = empty(&dictionary) ? '/usr/share/dict/words' : substitute(&dictionary, ',', ' ', 'g')
   return fzf#vim#complete(s:extend({
-    \ 'source': 'cat /usr/share/dict/words'},
+    \ 'source': 'cat ' . sources},
     \ get(a:000, 0, fzf#wrap())))
 endfunction
 


### PR DESCRIPTION
related: https://github.com/junegunn/fzf.vim/issues/1029

fzf could respect dictionary option by a few changes. And fzf will maintain the behavior of the previous version if user don't have dictionary option by default.