### PR TITLE
Feature - Action of multiple selection on Ag/Rg behavior like Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ let g:fzf_tags_command = 'ctags -R'
 
 " [Commands] --expect expression for directly executing the command
 let g:fzf_commands_expect = 'alt-enter,ctrl-x'
+
+" [Rg \ Ag] Actions on multiple lines will have the same behavior as `Files` command.
+" Default behavior - insert option into quickfix list.
+let g:ag_action_like_files = 1
 ```
 
 ### Advanced customization

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -736,6 +736,18 @@ function! s:ag_to_qf(line, has_column)
   return dict
 endfunction
 
+function! s:ag_open_at_line(cmd, line, has_column)
+  try
+    call s:open(a:cmd, a:line.filename)
+    execute a:line.lnum
+    if a:has_column
+      call cursor(0, a:line.col)
+    endif
+    normal! zvzz
+  catch
+  endtry
+endfunction
+
 function! s:ag_handler(lines, has_column)
   if len(a:lines) < 2
     return
@@ -747,18 +759,14 @@ function! s:ag_handler(lines, has_column)
     return
   endif
 
-  let first = list[0]
-  try
-    call s:open(cmd, first.filename)
-    execute first.lnum
-    if a:has_column
-      call cursor(0, first.col)
-    endif
-    normal! zvzz
-  catch
-  endtry
-
-  call s:fill_quickfix(list)
+  if get(g:, 'ag_action_like_files', 0)
+    for line in list
+      call s:ag_open_at_line(cmd, line, a:has_column)
+    endfor
+  else
+    call s:ag_open_at_line(cmd, list[0], a:has_column)
+    call s:fill_quickfix(list)
+  endif
 endfunction
 
 " query, [[ag options], options]


### PR DESCRIPTION
When you select multiple object with tab and then press (e.g.) <c-t> it opens in Quickfix list.
![image](https://user-images.githubusercontent.com/17852866/156770306-c7b9fbb9-a44c-4f94-81e9-1687442874e3.png)

Add an option to make it behave like `Files` with:
`let g:ag_action_like_files = 1`.

![image](https://user-images.githubusercontent.com/17852866/156770664-d512eaef-07a0-426c-8435-7aa4393ed17c.png)
 