### PR TITLE
Disable unicode for windows

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -158,7 +158,7 @@ function! fzf#vim#with_preview(...)
   if len(placeholder)
     let preview += ['--preview', preview_cmd.' '.placeholder]
   end
-  if &ambiwidth ==# 'double'
+  if &ambiwidth ==# 'double' || s:is_win
     let preview += ['--no-unicode']
   end
 


### PR DESCRIPTION
Hi, I use fzf.vim on Windows with `ambiwidth=single`. When I run any long operations like "Rg", my vim keeps bell and there's no way to disable it from vim side. It's quite annoying. It also doesn't matter whether I use cmd or powershell. I find it related to this [issue](https://github.com/junegunn/fzf/issues/2631) because I don't see the spinner characters. Instead I see characters like "&" or "8" and the bell has same rhythm with the chars.
<img width="212" alt="Screenshot" src="https://user-images.githubusercontent.com/4934907/157357647-737975fb-5522-4e63-bad5-b0362bb001bf.png">

My suggestion is to add "--no-unicode" to all windows machine. Or maybe we can add a flag to disable spinner chars only?
Tested on Windows 11, gVim 8.2.
