### PR TITLE
Mention fzf/ADVANCED.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,13 @@ endfunction
 command! -nargs=* -bang RG call RipgrepFzf(<q-args>, <bang>0)
 ```
 
+This can be further refined by letting `ripgrep` do the initial grepping, then switching 
+to `fzf` mode to filter the result list (this has the side effect that in the refining
+stage you can filter by file path too). Detailed examples can be found in the 
+[advanced fzf readme].
+
+[advanced fzf readme]: https://github.com/junegunn/fzf/blob/master/ADVANCED.md
+
 Mappings
 --------
 


### PR DESCRIPTION
Adds a link to the ADVANCED section of fzf readme where the interaction of fzf and ripgrep is explained in more detail. I found the ripgrep/fzf mode switching very useful and have been searching for how to implement this for a while before finding this page. Thus I think a link from here might help others as well. (While searching I also noticed some issues that were opened that could have probably be solved via the solutions described on the ADVANCED.md page).