### PR TITLE
Fix ctags language force for c plus plus

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -868,7 +868,7 @@ function! fzf#vim#buffer_tags(query, ...)
       let ctags_language_force = &filetype
   endif
   let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', ctags_language_force, escaped, null, sort),
+    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', get({ 'cpp': 'c++' }, &filetype, &filetype), escaped, null, sort),
     \ printf('ctags -f - --sort=yes --excmd=number %s 2> %s %s', escaped, null, sort)]
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -861,8 +861,14 @@ function! fzf#vim#buffer_tags(query, ...)
   let escaped = fzf#shellescape(expand('%'))
   let null = s:is_win ? 'nul' : '/dev/null'
   let sort = has('unix') && !has('win32unix') && executable('sort') ? '| sort -s -k 5' : ''
+  let ctags_language_force = &filetype
+  if (&filetype == 'cpp')
+      let ctags_language_force = 'c++'
+  else
+      let ctags_language_force = &filetype
+  endif
   let tag_cmds = (len(args) > 1 && type(args[0]) != type({})) ? remove(args, 0) : [
-    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', &filetype, escaped, null, sort),
+    \ printf('ctags -f - --sort=yes --excmd=number --language-force=%s %s 2> %s %s', ctags_language_force, escaped, null, sort),
     \ printf('ctags -f - --sort=yes --excmd=number %s 2> %s %s', escaped, null, sort)]
   if type(tag_cmds) != type([])
     let tag_cmds = [tag_cmds]


### PR DESCRIPTION
Filetype for c++ is 'cpp' in vim, however `--language-force` for c++ is `c++` in ctags.

For example, when i read the STL source code, i set the filetype of `string` file to `cpp` in vim. And using `:BTags`, there is a `no tags found` error. Then i try the below:

```sh
# ctags: Unknown language "cpp" in "language-force" option
ctags --language-force=cpp string
# ok
ctags --language-force=c++ string
```