### PR TITLE
Add clp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 
 - [fzf][fzf-main] 0.23.0 or above
 - For syntax-highlighted preview, install [bat](https://github.com/sharkdp/bat)
+  or [clp](https://github.com/jpe90/clp)
 - If [delta](https://github.com/dandavison/delta) is available, `GF?`,
   `Commits` and `BCommits` will use it to format `git diff` output.
 - `Ag` requires [The Silver Searcher (ag)][ag]
@@ -203,8 +204,9 @@ command! -bang -nargs=? -complete=dir Files
 
 It kind of works, but you probably want a nicer previewer program than `cat`.
 fzf.vim ships [a versatile preview script](bin/preview.sh) you can readily
-use. It internally executes [bat](https://github.com/sharkdp/bat) for syntax
-highlighting, so make sure to install it.
+use. It internally executes [bat](https://github.com/sharkdp/bat) or
+[clp](https://github.com/jpe90/clp) for syntax highlighting, so make sure to
+install one of them.
 
 ```vim
 command! -bang -nargs=? -complete=dir Files

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -52,6 +52,10 @@ if [ -z "$CENTER" ]; then
   CENTER=0
 fi
 
+if command -v clp > /dev/null; then
+	CLPNAME="clp"
+fi
+
 # Sometimes bat is installed as batcat.
 if command -v batcat > /dev/null; then
   BATNAME="batcat"
@@ -59,7 +63,12 @@ elif command -v bat > /dev/null; then
   BATNAME="bat"
 fi
 
-if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
+# Use clp if it's available
+if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${CLPNAME:+x}" ]; then
+  ${CLPNAME} --highlight-line="${CENTER}" \
+             "$FILE"
+  exit $?
+elif [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
   ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
       --highlight-line=$CENTER -- "$FILE"
   exit $?

--- a/bin/tagpreview.sh
+++ b/bin/tagpreview.sh
@@ -41,6 +41,10 @@ if (( START_LINE <= 0 )); then
 fi
 END_LINE="$(( START_LINE + FZF_PREVIEW_LINES - 1 ))"
 
+if command -v clp > /dev/null; then
+	CLPNAME="clp"
+fi
+
 # Sometimes bat is installed as batcat.
 if command -v batcat > /dev/null; then
   BATNAME="batcat"
@@ -48,7 +52,12 @@ elif command -v bat > /dev/null; then
   BATNAME="bat"
 fi
 
-if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
+# Use clp if it's available
+if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${CLPNAME:+x}" ]; then
+  ${CLPNAME} --highlight-line="${CENTER}" \
+             "$FILE"
+  exit $?
+elif [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
   ${BATNAME} --style="${BAT_STYLE:-numbers}" \
              --color=always \
              --pager=never \

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -91,18 +91,19 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
                                                           *fzf-vim-dependencies*
 
  - {fzf}{1} 0.23.0 or above
- - For syntax-highlighted preview, install {bat}{5}
+ - For syntax-highlighted preview, install {bat}{5} or {clp}{14}
  - If {delta}{6} is available, `GF?`, `Commits` and `BCommits` will use it to
    format `git diff` output.
  - `Ag` requires {The Silver Searcher (ag)}{7}
  - `Rg` requires {ripgrep (rg)}{8}
  - `Tags` and `Helptags` require Perl
 
-                             {1} https://github.com/junegunn/fzf
-                             {5} https://github.com/sharkdp/bat
-                             {6} https://github.com/dandavison/delta
-                             {7} https://github.com/ggreer/the_silver_searcher
-                             {8} https://github.com/BurntSushi/ripgrep
+                             {1}  https://github.com/junegunn/fzf
+                             {5}  https://github.com/sharkdp/bat
+                             {6}  https://github.com/dandavison/delta
+                             {7}  https://github.com/ggreer/the_silver_searcher
+                             {8}  https://github.com/BurntSushi/ripgrep
+                             {14} https://github.com/jpe90/clp
 
 
 COMMANDS                                                      *fzf-vim-commands*
@@ -272,8 +273,8 @@ Want a preview window?
 <
 It kind of works, but you probably want a nicer previewer program than `cat`.
 fzf.vim ships {a versatile preview script}{12} you can readily use. It
-internally executes {bat}{5} for syntax highlighting, so make sure to install
-it.
+internally executes {clp}{14} or {bat}{5} for syntax highlighting, so make sure to install
+one of them.
 >
     command! -bang -nargs=? -complete=dir Files
         \ call fzf#vim#files(<q-args>, {'options': ['--layout=reverse', '--info=inline', '--preview', '~/.vim/plugged/fzf.vim/bin/preview.sh {}']}, <bang>0)


### PR DESCRIPTION
This PR adds support for [clp](https://github.com/jpe90/clp) as an alternative to `bat` for file previewing.

In this implementation, `clp` is always used for file previewing if it's found. It assumes if the program is installed, the user would want to use it for file previewing, since that's its only function.

Alternatively a configuration option could be used to let users opt-in to `clp` more explicitly. Let me know if you would prefer doing it that way, or taking some other approach.