### PR TITLE
fix: GFiles is ignoring args

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -634,7 +634,7 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   let prefix = 'git -C ' . fzf#shellescape(root) . ' '
   if a:args != '?'
-    let source = prefix . 'ls-files -z'
+    let source = prefix . 'ls-files -z ' . a:args
     if s:git_version_requirement(2, 31)
       let source .= ' --deduplicate'
     endif


### PR DESCRIPTION
The commit linked below removed `a:args` from the `git ls-files` command, making it unable to take any options like `--cached`, `--others` and `--exclude-standard`

https://github.com/junegunn/fzf.vim/commit/531dd67350331771c0c099e9682a05744149e7b9