### PR TITLE
Fix: Windows preview window logic, including git diff preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ let g:fzf_preview_window = ['hidden,right,50%,<70(up,40%)', 'ctrl-/']
 
 " Empty value to disable preview window altogether
 let g:fzf_preview_window = []
+
+" fzf.vim needs bash to display the preview window.
+" On Windows, fzf.vim will first see if bash is in $PATH, then if
+" Git bash (C:\Program Files\Git\bin\bash.exe) is available.
+" If you want it to use a different bash, set this variable.
+" let g:fzf_preview_bash = 'C:\Git\bin\bash.exe'
 ```
 
 ### Command-local options

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -675,7 +675,7 @@ function! fzf#vim#gitfiles(args, ...)
   endif
   let prefix = 'git -C ' . fzf#shellescape(root) . ' '
   if a:args != '?'
-    let source = 'git -C ' . fzf#shellescape(root) . ' ls-files -z ' . a:args
+    let source = prefix . 'ls-files -z ' . a:args
     if s:git_version_requirement(2, 31)
       let source .= ' --deduplicate'
     endif

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -75,13 +75,13 @@ function! s:escape_for_bash(path)
   endif
 
   if !exists('s:is_linux_like_bash')
-    call system(s:bash . ' -c "ls /mnt/[A-Z]"')
+    call system(s:bash . ' -c "ls /mnt/[A-Za-z]"')
     let s:is_linux_like_bash = v:shell_error == 0
   endif
 
   let path = substitute(a:path, '\', '/', 'g')
   if s:is_linux_like_bash
-    let path = substitute(a:path, '^\([A-Z]\):', '/mnt/\L\1', '')
+    let path = substitute(path, '^\([A-Z]\):', '/mnt/\L\1', '')
   endif
 
   return escape(path, ' ')

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -40,6 +40,7 @@ function! s:winpath(path)
   return winpath
 endfunction
 
+let s:warned = 0
 function! s:bash()
   if exists('s:bash')
     return s:bash
@@ -98,7 +99,6 @@ let s:bin = {
 let s:TYPE = {'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 
 let s:wide = 120
-let s:warned = 0
 let s:checked = 0
 
 function! s:check_requirements()

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -14,11 +14,6 @@ if [ "$1" = --tag ]; then
   exit $?
 fi
 
-if [ "$1" = --bash-test ]; then
-  echo "Passed"
-  exit 0
-fi
-
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 CENTER=${INPUT[1]}

--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -14,6 +14,11 @@ if [ "$1" = --tag ]; then
   exit $?
 fi
 
+if [ "$1" = --bash-test ]; then
+  echo "Passed"
+  exit 0
+fi
+
 IFS=':' read -r -a INPUT <<< "$1"
 FILE=${INPUT[0]}
 CENTER=${INPUT[1]}

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -201,13 +201,6 @@ behavior with `g:fzf_preview_window`. Here are some examples:
     " unset by default.
     " For example: Git bash
     " let g:fzf_preview_win_bash = 'C:\Program Files\Git\bin\bash.exe'
-
-    " If you are completely sure which path rule bash you are using, you can also
-    " customize the type of bash you are using, it is recommended to keep unset.
-    " Unset by default. Again, Only works in Windows.
-    " 1 for linux-like bash(e.g default bash from WSL)
-    " 0 for others(e.g Git bash)
-    " let g:fzf_preview_win_bash_linux_like = 1
 <
 
 < Command-local options >_____________________________________________________~

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -195,6 +195,19 @@ behavior with `g:fzf_preview_window`. Here are some examples:
 
     " Empty value to disable preview window altogether
     let g:fzf_preview_window = []
+
+    " Custom set bash path, only for the preview window in Windows.
+    " You need to make sure the bash is executable under the Windows path rules.
+    " unset by default.
+    " For example: Git bash
+    " let g:fzf_preview_win_bash = 'C:\Program Files\Git\bin\bash.exe'
+
+    " If you are completely sure which path rule bash you are using, you can also
+    " customize the type of bash you are using, it is recommended to keep unset.
+    " Unset by default. Again, Only works in Windows.
+    " 1 for linux-like bash(e.g default bash from WSL)
+    " 0 for others(e.g Git bash)
+    " let g:fzf_preview_win_bash_linux_like = 1
 <
 
 < Command-local options >_____________________________________________________~

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -1,4 +1,4 @@
-fzf-vim.txt	fzf-vim	Last change: May 24 2021
+fzf-vim.txt	fzf-vim	Last change: January 15 2023
 FZF-VIM - TABLE OF CONTENTS                                *fzf-vim* *fzf-vim-toc*
 ==============================================================================
 
@@ -39,11 +39,11 @@ Things you can do with {fzf}{1} and Vim.
 RATIONALE                                                    *fzf-vim-rationale*
 ==============================================================================
 
-{fzf}{1} in itself is not a Vim plugin, and the official repository only
-provides the {basic wrapper function}{2} for Vim and it's up to the users to
-write their own Vim commands with it. However, I've learned that many users of
-fzf are not familiar with Vimscript and are looking for the "default"
-implementation of the features they can find in the alternative Vim plugins.
+{fzf}{1} itself is not a Vim plugin, and the official repository only provides
+the {basic wrapper function}{2} for Vim. It's up to the users to write their
+own Vim commands with it. However, I've learned that many users of fzf are not
+familiar with Vimscript and are looking for the "default" implementation of
+the features they can find in the alternative Vim plugins.
 
 This repository is a bundle of fzf-based commands and mappings extracted from
 my {.vimrc}{3} to address such needs. They are not designed to be flexible or
@@ -112,9 +112,9 @@ COMMANDS                                                      *fzf-vim-commands*
         *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
                                                           *:Helptags* *:Filetypes*
 
- ------------------+-----------------------------------------------------------------------
- Command           | List                                                                  ~
- ------------------+-----------------------------------------------------------------------
+ ------------------+--------------------------------------------------------------------------------------
+ Command           | List                                                                                 ~
+ ------------------+--------------------------------------------------------------------------------------
   `:Files [PATH]`    | Files (runs  `$FZF_DEFAULT_COMMAND`  if defined)
   `:GFiles [OPTS]`   | Git files ( `git ls-files` )
   `:GFiles?`         | Git files ( `git status` )
@@ -139,7 +139,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:Maps`            | Normal mode mappings
   `:Helptags`        | Help tags [1]
   `:Filetypes`       | File types
- ------------------+-----------------------------------------------------------------------
+ ------------------+--------------------------------------------------------------------------------------
 
                                                           *g:fzf_command_prefix*
 
@@ -196,11 +196,11 @@ behavior with `g:fzf_preview_window`. Here are some examples:
     " Empty value to disable preview window altogether
     let g:fzf_preview_window = []
 
-    " Custom set bash path, only for the preview window in Windows.
-    " You need to make sure the bash is executable under the Windows path rules.
-    " unset by default.
-    " For example: Git bash
-    " let g:fzf_preview_win_bash = 'C:\Program Files\Git\bin\bash.exe'
+    " fzf.vim needs bash to display the preview window.
+    " On Windows, fzf.vim will first see if bash is in $PATH, then if
+    " Git bash (C:\Program Files\Git\bin\bash.exe) is available.
+    " If you want it to use a different bash, set this variable.
+    " let g:fzf_preview_bash = 'C:\Git\bin\bash.exe'
 <
 
 < Command-local options >_____________________________________________________~


### PR DESCRIPTION
Fix preview window problems for Windows user.

I generally use Arch for development, but recently I also started using WSL, sometimes I don't want to open WSL, so I just open nvim in terminal and use it, I'm kind of a heavy user of `fzf.vim`, this plugin is really good. However, I found that the preview window reported various errors when using it directly in Windows (e.g. `nvim-qt`); 

I looked through the documentation and some other PRs, but I found that some of the solutions could cause another problem while solving one, so I tried to fix some of the problems and added an option to use other bash directly ( git bash, for example).

I've tried to minimize the impact on users using other environments, and I use WSL and Linux myself, so I understand the importance of stability.

Here's what I've tested, and even if it doesn't merge successfully, I hope this will help people who are having the same problem as me.

All with or without `delta`, `ag`.
All neovim use `packer`.
All vim use `plug`.

**Windows**: 
- [x] `neovim` and `vim x64` in `cmd` and `powershell`
- [x] `nvim-qt` and `gVim x64` 
- [x] `neovim` and `vim` in WSL - `ubuntu` and `Arch`
- [x] `Git bash` with vim 

`gVim x32` can not work properly because it can't access the bash under `C:\system32`, some people say 32bit can only access the files under `C:\Windows\Sysnative` but I don't have the environment to test it for now, replace it in the configuration file to other bash (such as `git bash`: `let g:fzf_preview_win_bash='C:\path\to\Git\bin\bash.exe'`) can work properly.

**Linux**:
- [x] Arch

**Mac**:
- [x] Maybe will test it next week . Tested: macOS Catalina 10.15.7 with neovim v0.8.2.


