### PR TITLE
docs: fix regex searches with shellescape for the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,7 @@ function! RipgrepFzf(query, fullscreen)
   let command_fmt = 'rg --column --line-number --no-heading --color=always --smart-case -- %s || true'
   let initial_command = printf(command_fmt, shellescape(a:query))
   let reload_command = printf(command_fmt, '{q}')
-  let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
-  let spec = fzf#vim#with_preview(spec, 'right', 'ctrl-/')
+  let spec = {'options': ['--disabled', '--query', shellescape(a:query), '--bind', 'change:reload:'.reload_command]}
   call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 


### PR DESCRIPTION
Fix regex regex searches in the example for Advanced ripgrep integration. Without this, regex searches are not functioning.