### PR TITLE
Update preview.sh to use bat's ability to jump to line range

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -27,6 +27,9 @@ if [[ -n "$CENTER" && ! "$CENTER" =~ ^[0-9] ]]; then
   exit 1
 fi
 CENTER=${CENTER/[^0-9]*/}
+(("BOTTOMRANGE=$CENTER - ($(tput lines)/2)"))
+(("BOTTOMRANGE=$BOTTOMRANGE < 0 ? 0 : $BOTTOMRANGE"))
+(("TOPRANGE=$BOTTOMRANGE+($(tput lines))"))
 
 # MS Win support
 if [[ "$FILE" =~ '\' ]]; then
@@ -60,9 +63,9 @@ elif command -v bat > /dev/null; then
 fi
 
 if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATNAME:+x}" ]; then
-  ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
-      --highlight-line=$CENTER -- "$FILE"
-  exit $?
+        ${BATNAME} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
+                --line-range $BOTTOMRANGE:$TOPRANGE --highlight-line=$CENTER -- "$FILE"
+        exit $?
 fi
 
 FILE_LENGTH=${#FILE}


### PR DESCRIPTION
When using bat, preview.sh will often end up trying to highlight lines that are off screen.

These days (since version 0.8, and it's on version 0.23, so a while), bat has the ability to specify a line range in the file to display.

We use it, plus the terminal height, to ensure the highlighted center line always visible.

We could use stty instead of tput to get terminal size, but everything i tried this on had tput available.

(Unfortunately, $LINES is only available in bash interactive shells)

Bat doesn't care if line-range specifies a range larger than the file, so TOPRANGE > number of lines in file is fine.