### PR TITLE
feat/add :changes command to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Commands
 | `:BTags [QUERY]`       | Tags in the current buffer                                                            |
 | `:Marks`               | Marks                                                                                 |
 | `:Jumps`               | Jumps                                                                                 |
+| `:Changes`             | Changes                                                                                 |
 | `:Windows`             | Windows                                                                               |
 | `:Locate PATTERN`      | `locate` command output                                                               |
 | `:History`             | `v:oldfiles` and open buffers                                                         |

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1233,11 +1233,13 @@ function! fzf#vim#changes(...)
   redir => cout
   silent changes
   redir END
-  let list = split(cout, "\n")
+  let s:changelist = split(cout, "\n")
+  let current = -match(s:changelist, '\v^\s*\>')
   return s:fzf('changes', {
-  \ 'source':  extend(list[0:0], map(list[1:], 's:format_change(v:val)')),
+  \ 'source':  extend(s:changelist[0:0], map(s:changelist[1:], 's:format_change(v:val)')),
   \ 'sink*':   s:function('s:change_sink'),
-  \ 'options': '+m -x --ansi --tiebreak=index --header-lines 1 --tiebreak=begin --prompt "Changes> "'}, a:000)
+  \ 'options' : '+m -x --ansi --tiebreak=index --cycle --scroll-off 999 --sync --bind start:pos:'.current.' --tac --header-lines 1 --tiebreak=begin --prompt "Changes> "',
+  \ }, a:000)
 endfunction
 
 " ------------------------------------------------------------------

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1214,7 +1214,7 @@ endfunction
 " Changes
 " ------------------------------------------------------------------
 function! s:format_change(line)
-  return substitute(a:line, '\d\{1,2}', '\=s:yellow(submatch(0), "Number")', '')
+    return substitute(a:line, '\d\+', '\=s:yellow(submatch(0), "Number")', '')
 endfunction
 
 function! s:change_sink(lines)
@@ -1233,10 +1233,10 @@ function! fzf#vim#changes(...)
   redir => cout
   silent changes
   redir END
-  let s:changelist = split(cout, "\n")
-  let current = -match(s:changelist, '\v^\s*\>')
+  let list = split(cout, "\n")
+  let current = -match(list, '\v^\s*\>')
   return s:fzf('changes', {
-  \ 'source':  extend(s:changelist[0:0], map(s:changelist[1:], 's:format_change(v:val)')),
+  \ 'source':  extend(list[0:0], map(list[1:], 's:format_change(v:val)')),
   \ 'sink*':   s:function('s:change_sink'),
   \ 'options' : '+m -x --ansi --tiebreak=index --cycle --scroll-off 999 --sync --bind start:pos:'.current.' --tac --header-lines 1 --tiebreak=begin --prompt "Changes> "',
   \ }, a:000)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1211,6 +1211,36 @@ function! fzf#vim#jumps(...)
 endfunction
 
 " ------------------------------------------------------------------
+" Changes
+" ------------------------------------------------------------------
+function! s:format_change(line)
+  return substitute(a:line, '\d\{1,2}', '\=s:yellow(submatch(0), "Number")', '')
+endfunction
+
+function! s:change_sink(lines)
+  if len(a:lines) < 2
+    return
+  endif
+  let cmd = s:action_for(a:lines[0])
+  if !empty(cmd)
+    execute 'silent' cmd
+  endif
+  let linecol = split(a:lines[1])
+  execute 'normal! '.linecol[1].'Gzz'
+endfunction
+
+function! fzf#vim#changes(...)
+  redir => cout
+  silent changes
+  redir END
+  let list = split(cout, "\n")
+  return s:fzf('changes', {
+  \ 'source':  extend(list[0:0], map(list[1:], 's:format_change(v:val)')),
+  \ 'sink*':   s:function('s:change_sink'),
+  \ 'options': '+m -x --ansi --tiebreak=index --header-lines 1 --tiebreak=begin --prompt "Changes> "'}, a:000)
+endfunction
+
+" ------------------------------------------------------------------
 " Help tags
 " ------------------------------------------------------------------
 function! s:helptag_sink(line)

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1214,7 +1214,7 @@ endfunction
 " Changes
 " ------------------------------------------------------------------
 function! s:format_change(line)
-    return substitute(a:line, '\d\+', '\=s:yellow(submatch(0), "Number")', '')
+  return substitute(a:line, '\d\+', '\=s:yellow(submatch(0), "Number")', '')
 endfunction
 
 function! s:change_sink(lines)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -107,8 +107,8 @@ COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
 
 *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:RG* *:Lines* *:BLines* *:Tags* *:BTags* *:Marks*
- *:Jumps* *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands* *:Maps*
-                                                          *:Helptags* *:Filetypes*
+ *:Jumps* *:Changes* *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits* *:Commands*
+                                                       *:Maps* *:Helptags* *:Filetypes*
 
  -----------------------+--------------------------------------------------------------------------------------
  Command                | List                                                                                 ~
@@ -127,6 +127,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:BTags [QUERY]`        | Tags in the current buffer
   `:Marks`                | Marks
   `:Jumps`                | Jumps
+  `:Changes`              | Changes
   `:Windows`              | Windows
   `:Locate PATTERN`       |  `locate`  command output
   `:History`              |  `v:oldfiles`  and open buffers

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -62,6 +62,7 @@ call s:defs([
 \'command! -bar -bang Commands                                  call fzf#vim#commands(<bang>0)',
 \'command! -bar -bang Jumps                                     call fzf#vim#jumps(<bang>0)',
 \'command! -bar -bang Marks                                     call fzf#vim#marks(<bang>0)',
+\'command! -bar -bang Changes                                   call fzf#vim#changes(<bang>0)',
 \'command! -bar -bang Helptags                                  call fzf#vim#helptags(fzf#vim#with_preview({ "placeholder": "--tag {2}:{3}:{4}" }), <bang>0)',
 \'command! -bar -bang Windows                                   call fzf#vim#windows(<bang>0)',
 \'command! -bar -bang -nargs=* -range=% -complete=file Commits  let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',


### PR DESCRIPTION
## WHAT

Added `:Changes` to the plugin to preview changes made inside a buffer and jump
on that line.

## WHY

Related to : https://github.com/junegunn/fzf.vim/issues/1479

## HOW

- feat: add :changes command from Vim as a fzf command to jump on the line of a change made
- doc: adapt the documentation

## DEMO

https://github.com/junegunn/fzf.vim/assets/22576758/ec44d9f9-c6eb-49e8-af07-c60bd9af9e4f


