### PR TITLE
Add preview for ":Windows"

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1261,7 +1261,7 @@ function! s:format_win(tab, win, buf)
   let name = bufname(a:buf)
   let name = empty(name) ? '[No Name]' : name
   let active = tabpagewinnr(a:tab) == a:win
-  return (active? s:blue('> ', 'Operator') : '  ') . name . (modified? s:red(' [+]', 'Exception') : '')
+  return (active? s:blue('> ', 'Operator') : s:black('> ', 'Ignore')) . name . (modified? s:red(' [+]', 'Exception') : '')
 endfunction
 
 function! s:windows_sink(line)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -63,7 +63,7 @@ call s:defs([
 \'command! -bar -bang Jumps                                     call fzf#vim#jumps(<bang>0)',
 \'command! -bar -bang Marks                                     call fzf#vim#marks(<bang>0)',
 \'command! -bar -bang Helptags                                  call fzf#vim#helptags(fzf#vim#with_preview({ "placeholder": "--tag {2}:{3}:{4}" }), <bang>0)',
-\'command! -bar -bang Windows                                   call fzf#vim#windows(<bang>0)',
+\'command! -bar -bang Windows                                   call fzf#vim#windows(fzf#vim#with_preview({ "placeholder": "{4}" }), <bang>0)',
 \'command! -bar -bang -nargs=* -range=% -complete=file Commits  let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
 \'command! -bar -bang -nargs=* -range=% BCommits                let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#buffer_commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
 \'command! -bar -bang Maps                                      call fzf#vim#maps("n", <bang>0)',


### PR DESCRIPTION
I've added/fixed the preview for the :Windows command. Since I have preview enabled from an environment variable, all I saw in the preview pane was an error message. I'd say it is generally useful to have the preview for :Windows, so I'll offer this PR.