### PR TITLE
tagpreview: open vim in readonly mode

### DIFF
--- a/bin/tagpreview.sh
+++ b/bin/tagpreview.sh
@@ -30,10 +30,10 @@ else
   exit 1
 fi
 
-CENTER="$("${VIMNAME}" -i NONE -u NONE -e -m -s "${FILE}" \
+CENTER="$("${VIMNAME}" -R -i NONE -u NONE -e -m -s "${FILE}" \
               -c "set nomagic" \
               -c "${EXCMD}" \
-              -c 'let l=line(".") | new | put =l | print | qa!')" || return
+              -c 'let l=line(".") | new | put =l | print | qa!')" || exit
 
 START_LINE="$(( CENTER - FZF_PREVIEW_LINES / 2 ))"
 if (( START_LINE <= 0 )); then


### PR DESCRIPTION
When computing the center line, if the file is open the vim command returns with a non-zero exit code and the `return` is executed. This yields a weird error message "return: can only `return'" in the preview window, even if the preview is properly displayed