### PR TITLE
qf buffers support

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -49,6 +49,7 @@ call s:defs([
 \'command!      -bang -nargs=? GitFiles                         call fzf#vim#gitfiles(<q-args>, fzf#vim#with_preview(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
 \'command!      -bang -nargs=? GFiles                           call fzf#vim#gitfiles(<q-args>, fzf#vim#with_preview(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
 \'command! -bar -bang -nargs=? -complete=buffer Buffers         call fzf#vim#buffers(<q-args>, fzf#vim#with_preview({ "placeholder": "{1}" }), <bang>0)',
+\'command! -bar -bang -nargs=? -complete=buffer Usages          call fzf#vim#qf_buffers(<q-args>, fzf#vim#with_preview({ "placeholder": "{1}" }), <bang>0)',
 \'command!      -bang -nargs=* Lines                            call fzf#vim#lines(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BLines                           call fzf#vim#buffer_lines(<q-args>, <bang>0)',
 \'command! -bar -bang Colors                                    call fzf#vim#colors(<bang>0)',


### PR DESCRIPTION
wanted to share this diff.

this is first time I wrote vimscript, so not elegant at all and very hacky.
but I have certain command that dump to qf. but fzf lets me filter and preview that list (using bat, which offers scroll).

This helps a lot when I just want to read some code from multiple files without actually switching buffer and such.

Feel free to use the diff as the way you like or just close the PR. But I would prefer to not carry this patch as updates might break