### PR TITLE
[[B]Commits] Bump Git commit hash length limit to 40

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1301,7 +1301,7 @@ function! s:commits_sink(lines)
     return
   endif
 
-  let pat = '[0-9a-f]\{7,9}'
+  let pat = '[0-9a-f]\{7,40}'
 
   if a:lines[0] == 'ctrl-y'
     let hashes = join(filter(map(a:lines[1:], 'matchstr(v:val, pat)'), 'len(v:val)'))


### PR DESCRIPTION
When working in large repositories, 9 characters can be ambiguous.
Bumping it to 40, which is the length of SHA-1. (The algorithm is not
that relevant though. Even when SHA-256 takes over, 40 characters should
still be enough for most repositories.)
