### PR TITLE
Add an option to open commands in different ways (`:Helptags`, `:Manpages`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Commands
 | `:Commands`            | Commands                                                                              |
 | `:Maps`                | Normal mode mappings                                                                  |
 | `:Helptags`            | Help tags <sup id="a1">[1](#helptags)</sup>                                           |
+| `:Manpages`            | Man pages                                                                             |
 | `:Filetypes`           | File types
 
 - Most commands support `CTRL-T` / `CTRL-X` / `CTRL-V` key

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1372,6 +1372,27 @@ function! fzf#vim#helptags(...)
 endfunction
 
 " ------------------------------------------------------------------
+" Man pages
+" ------------------------------------------------------------------
+function! s:manpage_sink(lines)
+  if len(a:lines) < 2
+    return
+  endif
+  let [page, section] = split(a:lines[1])[0:1]
+  if exists(":Man") != 2
+    runtime ftplugin/man.vim
+  endif
+  execute s:cmd_mod_for(a:lines[0]) 'Man' section[1:-2] page
+endfunction
+
+function! fzf#vim#manpages(...)
+  return s:fzf('manpages', {
+  \ 'source': 'man --apropos .',
+  \ 'sink*':   s:function('s:manpage_sink'),
+  \ 'options': ['--preview', 'man {1}', '--prompt=Man>']}, a:000)
+endfunction
+
+" ------------------------------------------------------------------
 " File types
 " ------------------------------------------------------------------
 function! fzf#vim#filetypes(...)

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -136,6 +136,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:Commands`             | Commands
   `:Maps`                 | Normal mode mappings
   `:Helptags`             | Help tags [1]
+  `:Manpages`             | Man pages
   `:Filetypes`            | File types
  -----------------------+--------------------------------------------------------------------------------------
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -70,6 +70,7 @@ call s:defs([
 \'command! -bar -bang Marks                                     call fzf#vim#marks(<bang>0)',
 \'command! -bar -bang Changes                                   call fzf#vim#changes(<bang>0)',
 \'command! -bar -bang Helptags                                  call fzf#vim#helptags(fzf#vim#with_preview({ "placeholder": "--tag {2}:{3}:{4}" }), <bang>0)',
+\'command! -bar -bang Manpages                                  call fzf#vim#manpages(<bang>0)',
 \'command! -bar -bang Windows                                   call fzf#vim#windows(fzf#vim#with_preview({ "placeholder": "{2}" }), <bang>0)',
 \'command! -bar -bang -nargs=* -range=% -complete=file Commits  let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
 \'command! -bar -bang -nargs=* -range=% BCommits                let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#buffer_commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',


### PR DESCRIPTION
This PR adds an option for commands that split a window to be opened in different ways. Currently this would only apply to `:Helptags` (#818).

I've also proposed a new `:Manpages` command (#1389) which would also make use of this option.

If this is something you'd like to incorporate I'd be happy to make a PR describing `g:fzf_cmd_mod` in [README-VIM](https://github.com/junegunn/fzf/blob/master/README-VIM.md#configuration).