### PR TITLE
[tags] Adds HTags command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -100,6 +100,7 @@ let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:bin_dir = expand('<sfile>:p:h:h:h').'/bin/'
 let s:bin = {
 \ 'preview': s:bin_dir.'preview.sh',
+\ 'tagsprefilter': s:bin_dir.'tagsprefilter.sh',
 \ 'tags':    s:bin_dir.'tags.pl' }
 let s:TYPE = {'bool': type(0), 'dict': type({}), 'funcref': type(function('call')), 'string': type(''), 'list': type([])}
 
@@ -1112,6 +1113,16 @@ function! fzf#vim#tags(query, ...)
 
   return s:fzf('tags', {
   \ 'source':  'perl '.fzf#shellescape(s:bin.tags).' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
+  \ 'sink*':   s:function('s:tags_sink'),
+  \ 'options': extend(opts, ['--nth', '1..2', '-m', '-d', '\t', '--tiebreak=begin', '--prompt', 'Tags> ', '--query', a:query])}, a:000)
+endfunction
+
+function! fzf#vim#heavytags(query, ...)
+  let tagfiles = tagfiles()
+  let opts = []
+
+  return s:fzf('heavytags', {
+  \ 'source':  s:bash() . ' ' . s:escape_for_bash(s:bin.tagsprefilter).' '.a:query.' '.join(map(tagfiles, 'fzf#shellescape(fnamemodify(v:val, ":p"))')),
   \ 'sink*':   s:function('s:tags_sink'),
   \ 'options': extend(opts, ['--nth', '1..2', '-m', '-d', '\t', '--tiebreak=begin', '--prompt', 'Tags> ', '--query', a:query])}, a:000)
 endfunction

--- a/bin/tagsprefilter.sh
+++ b/bin/tagsprefilter.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+QUERY="$1"
+shift
+TAGSFILES="$@"
+
+for t in ${TAGSFILES}; do
+    readtags -t "${t}" -e -p - "${QUERY}"  | sed 's/kind://' |  sed "s,$,\t${t},"
+done

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -103,7 +103,7 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
 
-       *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:RG* *:Lines* *:BLines* *:Tags* *:BTags*
+       *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:RG* *:Lines* *:BLines* *:Tags* *:BTags* *:HTags*
  *:Changes* *:Marks* *:Jumps* *:Windows* *:Locate* *:History* *:Snippets* *:Commits* *:BCommits*
                                           *:Commands* *:Maps* *:Helptags* *:Filetypes*
 
@@ -121,6 +121,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:Lines [QUERY]`        | Lines in loaded buffers
   `:BLines [QUERY]`       | Lines in the current buffer
   `:Tags [QUERY]`         | Tags in the project ( `ctags -R` )
+  `:HTags [QUERY]`        | Tags on large tags files
   `:BTags [QUERY]`        | Tags in the current buffer
   `:Changes`              | Changelist across all open buffers
   `:Marks`                | Marks
@@ -245,7 +246,7 @@ selected.
  - `Ag`
  - `Rg` / `RG`
  - `Lines` / `BLines`
- - `Tags` / `BTags`
+ - `Tags` / `BTags` / `HTags`
 
                                                             *g:fzf_vim.listproc*
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -63,6 +63,7 @@ call s:defs([
 \'command!      -bang -nargs=* Rg                               call fzf#vim#grep("rg --column --line-number --no-heading --color=always --smart-case -- ".fzf#shellescape(<q-args>), fzf#vim#with_preview(), <bang>0)',
 \'command!      -bang -nargs=* RG                               call fzf#vim#grep2("rg --column --line-number --no-heading --color=always --smart-case -- ", <q-args>, fzf#vim#with_preview(), <bang>0)',
 \'command!      -bang -nargs=* Tags                             call fzf#vim#tags(<q-args>, fzf#vim#with_preview({ "placeholder": "--tag {2}:{-1}:{3..}" }), <bang>0)',
+\'command!      -bang -nargs=* HTags                            call fzf#vim#heavytags(<q-args>, fzf#vim#with_preview({ "placeholder": "--tag {2}:{-1}:{3..}" }), <bang>0)',
 \'command!      -bang -nargs=* BTags                            call fzf#vim#buffer_tags(<q-args>, fzf#vim#with_preview({ "placeholder": "{2}:{3..}" }), <bang>0)',
 \'command! -bar -bang Snippets                                  call fzf#vim#snippets(<bang>0)',
 \'command! -bar -bang Commands                                  call fzf#vim#commands(<bang>0)',


### PR DESCRIPTION
HTags use readtags to prefilter requested tags, this is useful for large tags file where the perl processing takes some time and the search is long.

fix #1524