### PR TITLE
add scoop_git_bash to windows bash candidates

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -53,7 +53,8 @@ function! s:bash()
 
   let custom_bash = s:conf('preview_bash', '')
   let git_bash = 'C:\Program Files\Git\bin\bash.exe'
-  let candidates = filter(s:is_win ? [custom_bash, 'bash', git_bash] : [custom_bash, 'bash'], 'len(v:val)')
+  let scoop_git_bash = exists('$GIT_INSTALL_ROOT') ? '$GIT_INSTALL_ROOT' . '\bin\bash.exe : ''
+  let candidates = filter(s:is_win ? [custom_bash, git_bash, scoop_git_bash, 'bash'] : [custom_bash, 'bash'], 'len(v:val)')
 
   let found = filter(map(copy(candidates), 'exepath(v:val)'), 'len(v:val)')
   if empty(found)


### PR DESCRIPTION
This PR:
1) Adds scoop_git_bash to windows bash candidates. Scoop installs git for windows at ~/scoop/apps/git/current and sets the environment variable to $GIT_INSTALL_ROOT to this path.
2) Prioritizes Windows' bash over wsl bash. WSL bash causes errors for many reasons, some of which include:
    - wsl bash may exist on the $PATH but not be installed
    - wsl may not be started (which *may* cause an error)
    - wsl cannot start due to hyper-v being disabled

Tested successfully on:
- vim + Git Bash / mintty
- nvim + cmd

nvim + Git Bash doesn't work and hasn't worked for quite a while.