### PR TITLE
[fzf#vim#grep / Ag / Rg / RG] Multi-line display for narrow screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,20 @@ let g:fzf_vim.preview_window = []
 #### Command-level options
 
 ```vim
-" [Buffers] Jump to the existing window if possible
+" [Buffers] Jump to the existing window if possible (default: 0)
 let g:fzf_vim.buffers_jump = 1
+
+" [Ag|Rg|RG] Display path on a separate line for narrow screens (default: 0)
+" * Requires Perl and fzf 0.53.0 or later
+let g:fzf_vim.grep_multi_line = 0
+   " PATH:LINE:COL:LINE
+let g:fzf_vim.grep_multi_line = 1
+   " PATH:LINE:COL:
+   " LINE
+let g:fzf_vim.grep_multi_line = 2
+   " PATH:LINE:COL:
+   " LINE
+   " (empty line)
 
 " [[B]Commits] Customize the options used by 'git log':
 let g:fzf_vim.commits_log_options = '--graph --color=always --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'


### PR DESCRIPTION
Display PATH:LINE:COL on a separate line for narrow screens. Requires Perl and fzf 0.53.0 (not yet released).

* See https://github.com/junegunn/fzf/pull/3807

## Usage

```vim
" [Ag|Rg|RG] Display path on a separate line for narrow screens (default: 0)
" * Requires Perl and fzf 0.53.0 or later
let g:fzf_vim.grep_multi_line = 0
   " PATH:LINE:COL:LINE
let g:fzf_vim.grep_multi_line = 1
   " PATH:LINE:COL:
   " LINE
let g:fzf_vim.grep_multi_line = 2
   " PATH:LINE:COL:
   " LINE
   " (empty line)
```

## Screenshots

### `let g:fzf_vim.grep_multi_line = 0`

<img width="1572" alt="image" src="https://github.com/junegunn/fzf.vim/assets/700826/c162d747-8948-43d4-85e5-4056c8d65ff4">


### `let g:fzf_vim.grep_multi_line = 1`

<img width="1566" alt="image" src="https://github.com/junegunn/fzf.vim/assets/700826/245b7d8f-47c0-401a-90bb-9b706c053d74">


### `let g:fzf_vim.grep_multi_line = 2`

<img width="1574" alt="image" src="https://github.com/junegunn/fzf.vim/assets/700826/66428e92-d826-404e-8a7d-fb296a75ac62">
