### PR TITLE
autoload/fzf: get_git_root, wrap system call with fzf#with_sh

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -712,12 +712,9 @@ endfunction
 
 function! s:get_git_root(dir)
   let dir = len(a:dir) ? a:dir : substitute(split(expand('%:p:h'), '[/\\]\.git\([/\\]\|$\)')[0], '^fugitive://', '', '')
-  if &shell ==# 'cmd'
-    let dir = fzf#shellescape(dir)
-  elseif &shell ==# 'pwsh'
-    let dir = '"'.dir.'"'
-  endif
-  let root = systemlist('git -C ' . dir . ' rev-parse --show-toplevel')[0]
+  let [shell, shellslash, shellcmdflag, shellxquote] = fzf#use_sh()
+  let root = systemlist('git -C ' . fzf#shellescape(dir) . ' rev-parse --show-toplevel')[0]
+  let [&shell, &shellslash, &shellcmdflag, &shellxquote] = [shell, shellslash, shellcmdflag, shellxquote]
   return v:shell_error ? '' : (len(a:dir) ? fnamemodify(a:dir, ':p') : root)
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -712,7 +712,7 @@ endfunction
 
 function! s:get_git_root(dir)
   let dir = len(a:dir) ? a:dir : substitute(split(expand('%:p:h'), '[/\\]\.git\([/\\]\|$\)')[0], '^fugitive://', '', '')
-  let root = fzf#with_sh({ -> systemlist('git -C ' . fzf#shellescape(dir) . ' rev-parse --show-toplevel')[0] })
+  let root = systemlist('git -C ' . shellescape(dir) . ' rev-parse --show-toplevel')[0]
   return v:shell_error ? '' : (len(a:dir) ? fnamemodify(a:dir, ':p') : root)
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -712,7 +712,12 @@ endfunction
 
 function! s:get_git_root(dir)
   let dir = len(a:dir) ? a:dir : substitute(split(expand('%:p:h'), '[/\\]\.git\([/\\]\|$\)')[0], '^fugitive://', '', '')
-  let root = systemlist('git -C ' . fzf#shellescape(dir) . ' rev-parse --show-toplevel')[0]
+  if &shell ==# 'cmd'
+    let dir = fzf#shellescape(dir)
+  elseif &shell ==# 'pwsh'
+    let dir = '"'.dir.'"'
+  endif
+  let root = systemlist('git -C ' . dir . ' rev-parse --show-toplevel')[0]
   return v:shell_error ? '' : (len(a:dir) ? fnamemodify(a:dir, ':p') : root)
 endfunction
 

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -712,9 +712,7 @@ endfunction
 
 function! s:get_git_root(dir)
   let dir = len(a:dir) ? a:dir : substitute(split(expand('%:p:h'), '[/\\]\.git\([/\\]\|$\)')[0], '^fugitive://', '', '')
-  let [shell, shellslash, shellcmdflag, shellxquote] = fzf#use_sh()
-  let root = systemlist('git -C ' . fzf#shellescape(dir) . ' rev-parse --show-toplevel')[0]
-  let [&shell, &shellslash, &shellcmdflag, &shellxquote] = [shell, shellslash, shellcmdflag, shellxquote]
+  let root = fzf#with_sh({ -> systemlist('git -C ' . fzf#shellescape(dir) . ' rev-parse --show-toplevel')[0] })
   return v:shell_error ? '' : (len(a:dir) ? fnamemodify(a:dir, ':p') : root)
 endfunction
 


### PR DESCRIPTION
This aims too fix an issue expressed over here:

https://github.com/junegunn/fzf/issues/3188

Instead of going with the fix attempt over here:

https://github.com/junegunn/fzf/pull/4264

From what I can tell, only git commands are broken in the setting where `&shell=pwsh` and it's because of the escaping of characters in the path. In pwsh, you only need to quote a string and the path should be resolved correctly.