### PR TITLE
fix(preview): never preview binary files

### DIFF
--- a/bin/preview.sh
+++ b/bin/preview.sh
@@ -66,17 +66,17 @@ if [[ -z "$BATCAT" ]]; then
   fi
 fi
 
-if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATCAT:+x}" ] && [[ ! -d "$FILE" ]] ; then
-  ${BATCAT} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
-      --highlight-line=$CENTER -- "$FILE"
-  exit $?
-fi
-
 FILE_LENGTH=${#FILE}
 MIME=$(file --dereference --mime -- "$FILE")
 if [[ "${MIME:FILE_LENGTH}" =~ binary ]] && [[ ! -d "$FILE" ]]; then
   echo "$MIME"
   exit 0
+fi
+
+if [ -z "$FZF_PREVIEW_COMMAND" ] && [ "${BATCAT:+x}" ] && [[ ! -d "$FILE" ]] ; then
+  ${BATCAT} --style="${BAT_STYLE:-numbers}" --color=always --pager=never \
+      --highlight-line=$CENTER -- "$FILE"
+  exit $?
 fi
 
 DEFAULT_COMMAND="highlight -O ansi -l {} || coderay {} || rougify {} || cat {}"


### PR DESCRIPTION

I think this is a bug fix instead of a new feature.  The reason for this is
that the current behavior _overrides user choice_ of `FZF_PREVIEW_COMMAND`. No
matter what preview command they provide, we never run it on binary files.
However, if the user supplies _no_ preview command, then we'll run it through
`bat` which produces an error.  This sounds like a mistake.

This commit makes the behavior when no preview command is supplied the same as
the behavior when a preview command is given.

Before:
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/d5f66828-5a17-439d-bd62-b670e6e9e2e9" />

After:
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/dd1d811d-fdc0-4023-8bfa-e97e5b9fdca5" />
