### PR TITLE
feat: Allow passing arguments of :marks to :Marks command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1362,11 +1362,22 @@ function! s:mark_sink(lines)
   execute 'normal! `'.matchstr(a:lines[1], '\S').'zz'
 endfunction
 
-function! fzf#vim#marks(...)
+function! fzf#vim#marks(initial_marks, ...)
   redir => cout
-  silent marks
+  if empty(a:initial_marks)
+    silent marks
+  else
+    execute 'silent! marks' a:initial_marks
+  endif
   redir END
+
   let list = split(cout, "\n")
+
+  " If 1st entry is not header, i.e. errors then just display header
+  if list[0] != 'mark line  col file/text'
+    let list = ['mark line  col file/text']
+  endif
+
   return s:fzf('marks', {
   \ 'source':  extend(list[0:0], map(list[1:], 's:format_mark(v:val)')),
   \ 'sink*':   s:function('s:mark_sink'),

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -68,6 +68,7 @@ call s:defs([
 \'command! -bar -bang Commands                                  call fzf#vim#commands(<bang>0)',
 \'command! -bar -bang Jumps                                     call fzf#vim#jumps(fzf#vim#with_preview({ "placeholder": "{2..4}"}), <bang>0)',
 \'command! -bar -bang -nargs=* Marks                            call fzf#vim#marks(<q-args>, <bang>0)',
+\'command! -bar -bang -nargs=* BMarks                           call fzf#vim#marks("abcdefghijklmnopqrstuvwxyz", <bang>0)',
 \'command! -bar -bang Changes                                   call fzf#vim#changes(<bang>0)',
 \'command! -bar -bang Helptags                                  call fzf#vim#helptags(fzf#vim#with_preview({ "placeholder": "--tag {2}:{3}:{4}" }), <bang>0)',
 \'command! -bar -bang Windows                                   call fzf#vim#windows(fzf#vim#with_preview({ "placeholder": "{2}" }), <bang>0)',

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -67,7 +67,7 @@ call s:defs([
 \'command! -bar -bang Snippets                                  call fzf#vim#snippets(<bang>0)',
 \'command! -bar -bang Commands                                  call fzf#vim#commands(<bang>0)',
 \'command! -bar -bang Jumps                                     call fzf#vim#jumps(fzf#vim#with_preview({ "placeholder": "{2..4}"}), <bang>0)',
-\'command! -bar -bang Marks                                     call fzf#vim#marks(<bang>0)',
+\'command! -bar -bang -nargs=* Marks                            call fzf#vim#marks(<q-args>, <bang>0)',
 \'command! -bar -bang Changes                                   call fzf#vim#changes(<bang>0)',
 \'command! -bar -bang Helptags                                  call fzf#vim#helptags(fzf#vim#with_preview({ "placeholder": "--tag {2}:{3}:{4}" }), <bang>0)',
 \'command! -bar -bang Windows                                   call fzf#vim#windows(fzf#vim#with_preview({ "placeholder": "{2}" }), <bang>0)',


### PR DESCRIPTION
This PR allows passing initial mark filtering of `:marks` command to `:Marks`. As a result, this also introduces new command `:BMarks` that only list marks in the buffer (i.e. marks `a-z`).

<img width="2560" alt="Screenshot 2025-06-05 at 19 12 48" src="https://github.com/user-attachments/assets/8bf5025a-6519-4c42-b8fe-a1655803cf35" />

Related issue: https://github.com/junegunn/fzf.vim/issues/1158