### PR TITLE
add  commit count to :GFiles to restrict to last <count> commits

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -713,6 +713,59 @@ endfunction
 " GFiles[?]
 " ------------------------------------------------------------------
 
+function! fzf#vim#gfiles(bang, count, args) abort
+  " When count is negative, fall back to the original GFiles behavior
+  if a:count < 0
+    return fzf#vim#gitfiles(a:args, fzf#vim#with_preview(a:args == '?' ? { 'placeholder': '' } : {}), a:bang)
+  endif
+
+  let root = s:get_git_root('')
+  if empty(root)
+    return s:warn('Not in git repo')
+  endif
+
+  " Count 0 behaves like :GFiles? (git status)
+  if a:count == 0
+    return fzf#vim#gitfiles('?', fzf#vim#with_preview({ 'placeholder': '' }), a:bang)
+  endif
+
+  " Positive count: files changed in the last {count} commits
+  let filter = s:is_win ? 'findstr /v "^$"' : 'sed -e /^$/d'
+  let prefix = 'git -C ' . fzf#shellescape(root) . ' '
+  let source = prefix . 'log HEAD --max-count='.a:count.
+        \ ' --diff-filter=MA --name-only --pretty=format: | '.filter
+
+  let opts = ['--scheme', 'path', '--prompt', 'GitFiles?> ']
+
+  if executable('git') && executable(s:bash())
+    let bar = s:is_win ? '^|' : '|'
+    let diff_prefix = 'git -C ' . s:escape_for_bash(root) . ' '
+    if executable('delta')
+      let diff =
+            \ diff_prefix
+            \ . 'diff --color=always HEAD~'.a:count.'..HEAD -- {-1} '
+            \ . bar . ' delta --width $FZF_PREVIEW_COLUMNS --file-style=omit '
+            \ . bar . ' sed 1d'
+    else
+      let diff =
+            \ diff_prefix
+            \ . 'diff --color=always HEAD~'.a:count.'..HEAD -- {-1} '
+            \ . bar . ' sed 1,4d'
+    endif
+    let preview_cmd = s:bash() . ' -c "'.diff.'"'
+    call extend(opts, [
+          \ '--preview',        preview_cmd,
+          \ '--preview-window', 'right,50%,<70(up,40%)',
+          \ ])
+  endif
+
+  return s:fzf('gfiles-diff', {
+  \ 'source':  source,
+  \ 'dir':     root,
+  \ 'options': opts
+  \}, [a:bang])
+endfunction
+
 function! s:get_git_root(dir)
   if empty(a:dir) && exists('*FugitiveWorkTree')
     return FugitiveWorkTree()

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -117,7 +117,9 @@ COMMANDS                                                      *fzf-vim-commands*
  Command                | List                                                                                 ~
  -----------------------+--------------------------------------------------------------------------------------
   `:Files [PATH]`         | Files (runs  `$FZF_DEFAULT_COMMAND`  if defined)
-  `:GFiles [OPTS]`        | Git files ( `git ls-files` )
+  `:[count]GFiles [OPTS]` | Git files ( `git ls-files` )
+                          | With [count] > 0, restrict to files changed in the last [count] commits; 0 is
+                          | equivalent to `:GFiles?` (also available by passing `?` as [OPTS])
   `:GFiles?`              | Git files ( `git status` )
   `:Buffers`              | Open buffers
   `:Colors`               | Color schemes

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -53,7 +53,7 @@ endfunction
 call s:defs([
 \'command!      -bang -nargs=? -complete=dir Files              call fzf#vim#files(<q-args>, fzf#vim#with_preview(), <bang>0)',
 \'command!      -bang -nargs=? GitFiles                         call fzf#vim#gitfiles(<q-args>, fzf#vim#with_preview(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
-\'command!      -bang -nargs=? GFiles                           call fzf#vim#gitfiles(<q-args>, fzf#vim#with_preview(<q-args> == "?" ? { "placeholder": "" } : {}), <bang>0)',
+\'command!      -bang -count=0 -nargs=? GFiles                  call fzf#vim#gfiles(<bang>0, <range> == 0 ? -1 : <count>, <q-args>)',
 \'command! -bar -bang -nargs=? -complete=buffer Buffers         call fzf#vim#buffers(<q-args>, fzf#vim#with_preview({ "placeholder": "{1}" }), <bang>0)',
 \'command!      -bang -nargs=* Lines                            call fzf#vim#lines(<q-args>, <bang>0)',
 \'command!      -bang -nargs=* BLines                           call fzf#vim#buffer_lines(<q-args>, <bang>0)',


### PR DESCRIPTION
Let `:GFiles` take a count to restrict to those files altered in last <count> commits.
Count 0 corresponds to `:GFiles?` kept for backwards compatibility.
Builds in [this snippet](https://gist.github.com/Konfekt/429eb0f4d9a17e31235f49c4716ffddb)