### PR TITLE
add :References command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,34 +79,34 @@ Commands
 
 | Command                | List                                                                                  |
 | ---                    | ---                                                                                   |
+| `:Ag [PATTERN]`        | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all)               |
+| `:BCommits [LOG_OPTS]` | Git commits for the current buffer; visual-select lines to track changes in the range |
+| `:BLines [QUERY]`      | Lines in the current buffer                                                           |
+| `:BMarks`              | Marks in the current buffer                                                           |
+| `:BTags [QUERY]`       | Tags in the current buffer                                                            |
+| `:Buffers`             | Open buffers                                                                          |
+| `:Changes`             | Changelist across all open buffers                                                    |
+| `:Colors`              | Color schemes                                                                         |
+| `:Commands`            | Commands                                                                              |
+| `:Commits [LOG_OPTS]`  | Git commits (requires [fugitive.vim][f])                                              |
 | `:Files [PATH]`        | Files (runs `$FZF_DEFAULT_COMMAND` if defined)                                        |
+| `:Filetypes`           | File types                                                                            |
 | `:GFiles [OPTS]`       | Git files (`git ls-files`)                                                            |
 | `:GFiles?`             | Git files (`git status`)                                                              |
-| `:Buffers`             | Open buffers                                                                          |
-| `:Colors`              | Color schemes                                                                         |
-| `:Ag [PATTERN]`        | [ag][ag] search result (`ALT-A` to select all, `ALT-D` to deselect all)               |
-| `:Rg [PATTERN]`        | [rg][rg] search result (`ALT-A` to select all, `ALT-D` to deselect all)               |
-| `:RG [PATTERN]`        | [rg][rg] search result; relaunch ripgrep on every keystroke                           |
-| `:Lines [QUERY]`       | Lines in loaded buffers                                                               |
-| `:BLines [QUERY]`      | Lines in the current buffer                                                           |
-| `:Tags [PREFIX]`       | Tags in the project (`ctags -R`)                                                      |
-| `:BTags [QUERY]`       | Tags in the current buffer                                                            |
-| `:Changes`             | Changelist across all open buffers                                                    |
-| `:Marks`               | Marks                                                                                 |
-| `:BMarks`              | Marks in the current buffer                                                           |
-| `:Jumps`               | Jumps                                                                                 |
-| `:Windows`             | Windows                                                                               |
-| `:Locate PATTERN`      | `locate` command output                                                               |
-| `:History`             | `v:oldfiles` and open buffers                                                         |
-| `:History:`            | Command history                                                                       |
-| `:History/`            | Search history                                                                        |
-| `:Snippets`            | Snippets ([UltiSnips][us])                                                            |
-| `:Commits [LOG_OPTS]`  | Git commits (requires [fugitive.vim][f])                                              |
-| `:BCommits [LOG_OPTS]` | Git commits for the current buffer; visual-select lines to track changes in the range |
-| `:Commands`            | Commands                                                                              |
-| `:Maps`                | Normal mode mappings                                                                  |
 | `:Helptags`            | Help tags <sup id="a1">[1](#helptags)</sup>                                           |
-| `:Filetypes`           | File types
+| `:History/`            | Search history                                                                        |
+| `:History:`            | Command history                                                                       |
+| `:History`             | `v:oldfiles` and open buffers                                                         |
+| `:Jumps`               | Jumps                                                                                 |
+| `:Lines [QUERY]`       | Lines in loaded buffers                                                               |
+| `:Locate PATTERN`      | `locate` command output                                                               |
+| `:Maps`                | Normal mode mappings                                                                  |
+| `:Marks`               | Marks                                                                                 |
+| `:RG [PATTERN]`        | [rg][rg] search result; relaunch ripgrep on every keystroke                           |
+| `:Rg [PATTERN]`        | [rg][rg] search result (`ALT-A` to select all, `ALT-D` to deselect all)               |
+| `:Snippets`            | Snippets ([UltiSnips][us])                                                            |
+| `:Tags [PREFIX]`       | Tags in the project (`ctags -R`)                                                      |
+| `:Windows`             | Windows                                                                               |
 
 - Most commands support `CTRL-T` / `CTRL-X` / `CTRL-V` key
   bindings to open in a new tab, a new split, or in a new vertical split

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Commands
 | `:Locate PATTERN`      | `locate` command output                                                               |
 | `:Maps`                | Normal mode mappings                                                                  |
 | `:Marks`               | Marks                                                                                 |
+| `:References`          | [ALE][ale] `:ALEFindReferences` symbol search result
 | `:RG [PATTERN]`        | [rg][rg] search result; relaunch ripgrep on every keystroke                           |
 | `:Rg [PATTERN]`        | [rg][rg] search result (`ALT-A` to select all, `ALT-D` to deselect all)               |
 | `:Snippets`            | Snippets ([UltiSnips][us])                                                            |
@@ -487,3 +488,4 @@ MIT
 [ag]:    https://github.com/ggreer/the_silver_searcher
 [rg]:    https://github.com/BurntSushi/ripgrep
 [us]:    https://github.com/SirVer/ultisnips
+[ale]:    https://github.com/dense-analysis/ale

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -1832,5 +1832,21 @@ function! fzf#vim#complete(...)
 endfunction
 
 " ------------------------------------------------------------------
+" References (ALE)
+" ------------------------------------------------------------------
+"
+function! fzf#vim#alefindreferences(...)
+  if !exists(':ALEFindReferences')
+    return s:warn('ALE not found')
+  endif
+  let l:args = copy(a:000)
+  if index(a:000, '-fzf') == -1
+    call add(l:args, '-fzf')
+  endif
+
+  return call("ale#references#Find", l:args)
+endfunction
+
+" ------------------------------------------------------------------
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -108,42 +108,41 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
 
 COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
-
-       *:Files* *:GFiles* *:Buffers* *:Colors* *:Ag* *:Rg* *:RG* *:Lines* *:BLines* *:Tags* *:BTags*
-   *:Changes* *:Marks* *:BMarks* *:Jumps* *:Windows* *:Locate* *:History* *:Snippets* *:Commits*
-                                *:BCommits* *:Commands* *:Maps* *:Helptags* *:Filetypes*
+      *:Ag* *:BCommits* *:BLines* *:BMarks* *:BTags* *:Buffers* *:Changes* *:Colors* *:Commands*
+           *:Commits* *:Files* *:Filetypes* *:GFiles* *:Helptags* *:History* *:Jumps* *:Lines*
+                         *:Locate* *:Maps* *:Marks* *:RG* *:Rg* *:Snippets* *:Tags* *:Windows*
 
  -----------------------+--------------------------------------------------------------------------------------
  Command                | List                                                                                 ~
  -----------------------+--------------------------------------------------------------------------------------
+  `:Ag [PATTERN]`         | {ag}{6} search result ( `ALT-A`  to select all,  `ALT-D`  to deselect all)
+  `:BCommits [LOG_OPTS]`  | Git commits for the current buffer; visual-select lines to track changes in the range
+  `:BLines [QUERY]`       | Lines in the current buffer
+  `:BMarks`               | Marks in the current buffer
+  `:BTags [QUERY]`        | Tags in the current buffer
+  `:Buffers`              | Open buffers
+  `:Changes`              | Changelist across all open buffers
+  `:Colors`               | Color schemes
+  `:Commands`             | Commands
+  `:Commits [LOG_OPTS]`   | Git commits (requires {fugitive.vim}{10})
   `:Files [PATH]`         | Files (runs  `$FZF_DEFAULT_COMMAND`  if defined)
+  `:Filetypes`            | File types
   `:GFiles [OPTS]`        | Git files ( `git ls-files` )
   `:GFiles?`              | Git files ( `git status` )
-  `:Buffers`              | Open buffers
-  `:Colors`               | Color schemes
-  `:Ag [PATTERN]`         | {ag}{6} search result ( `ALT-A`  to select all,  `ALT-D`  to deselect all)
-  `:Rg [PATTERN]`         | {rg}{7} search result ( `ALT-A`  to select all,  `ALT-D`  to deselect all)
-  `:RG [PATTERN]`         | {rg}{7} search result; relaunch ripgrep on every keystroke
-  `:Lines [QUERY]`        | Lines in loaded buffers
-  `:BLines [QUERY]`       | Lines in the current buffer
-  `:Tags [PREFIX]`        | Tags in the project ( `ctags -R` )
-  `:BTags [QUERY]`        | Tags in the current buffer
-  `:Changes`              | Changelist across all open buffers
-  `:Marks`                | Marks
-  `:BMarks`               | Marks in the current buffer
-  `:Jumps`                | Jumps
-  `:Windows`              | Windows
-  `:Locate PATTERN`       |  `locate`  command output
-  `:History`              |  `v:oldfiles`  and open buffers
-  `:History:`             | Command history
-  `:History/`             | Search history
-  `:Snippets`             | Snippets ({UltiSnips}{9})
-  `:Commits [LOG_OPTS]`   | Git commits (requires {fugitive.vim}{10})
-  `:BCommits [LOG_OPTS]`  | Git commits for the current buffer; visual-select lines to track changes in the range
-  `:Commands`             | Commands
-  `:Maps`                 | Normal mode mappings
   `:Helptags`             | Help tags [1]
-  `:Filetypes`            | File types
+  `:History/`             | Search history
+  `:History:`             | Command history
+  `:History`              |  `v:oldfiles`  and open buffers
+  `:Jumps`                | Jumps
+  `:Lines [QUERY]`        | Lines in loaded buffers
+  `:Locate PATTERN`       |  `locate`  command output
+  `:Maps`                 | Normal mode mappings
+  `:Marks`                | Marks
+  `:RG [PATTERN]`         | {rg}{7} search result; relaunch ripgrep on every keystroke
+  `:Rg [PATTERN]`         | {rg}{7} search result ( `ALT-A`  to select all,  `ALT-D`  to deselect all)
+  `:Snippets`             | Snippets ({UltiSnips}{9})
+  `:Tags [PREFIX]`        | Tags in the project ( `ctags -R` )
+  `:Windows`              | Windows
  -----------------------+--------------------------------------------------------------------------------------
 
                                                       *g:fzf_vim.command_prefix*

--- a/doc/fzf-vim.txt
+++ b/doc/fzf-vim.txt
@@ -94,6 +94,7 @@ so you can omit it if you use a plugin manager that doesn't support hooks.
  - `Rg` requires {ripgrep (rg)}{7}
  - `Tags` and `Helptags` require Perl
  - `Tags PREFIX` requires `readtags` command from {Universal Ctags}{8}
+ - `References` requires `:ALEFindReferences` command from {ALE}{9}
 >
     # Installing dependencies using Homebrew
     brew install fzf bat ripgrep the_silver_searcher perl universal-ctags
@@ -110,7 +111,7 @@ COMMANDS                                                      *fzf-vim-commands*
 ==============================================================================
       *:Ag* *:BCommits* *:BLines* *:BMarks* *:BTags* *:Buffers* *:Changes* *:Colors* *:Commands*
            *:Commits* *:Files* *:Filetypes* *:GFiles* *:Helptags* *:History* *:Jumps* *:Lines*
-                         *:Locate* *:Maps* *:Marks* *:RG* *:Rg* *:Snippets* *:Tags* *:Windows*
+             *:Locate* *:Maps* *:Marks* *:References* *:RG* *:Rg* *:Snippets* *:Tags* *:Windows*
 
  -----------------------+--------------------------------------------------------------------------------------
  Command                | List                                                                                 ~
@@ -138,6 +139,7 @@ COMMANDS                                                      *fzf-vim-commands*
   `:Locate PATTERN`       |  `locate`  command output
   `:Maps`                 | Normal mode mappings
   `:Marks`                | Marks
+  `:References`           | References to the symbol under the cursor (requires {ALE}{12}'s |ALEFindReferences|)
   `:RG [PATTERN]`         | {rg}{7} search result; relaunch ripgrep on every keystroke
   `:Rg [PATTERN]`         | {rg}{7} search result ( `ALT-A`  to select all,  `ALT-D`  to deselect all)
   `:Snippets`             | Snippets ({UltiSnips}{9})
@@ -162,6 +164,7 @@ But its functionality is still available via `call pathogen#helptags()`. [↩])
                              {9} https://github.com/SirVer/ultisnips
                              {10} https://github.com/tpope/vim-fugitive
                              {11} https://github.com/tpope/vim-pathogen
+                             {12} https://github.com/dense-analysis/ale
 
 
 CUSTOMIZATION                                            *fzf-vim-customization*

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -76,7 +76,8 @@ call s:defs([
 \'command! -bar -bang -nargs=* -range=% BCommits                let b:fzf_winview = winsaveview() | <line1>,<line2>call fzf#vim#buffer_commits(<q-args>, fzf#vim#with_preview({ "placeholder": "" }), <bang>0)',
 \'command! -bar -bang Maps                                      call fzf#vim#maps("n", <bang>0)',
 \'command! -bar -bang Filetypes                                 call fzf#vim#filetypes(<bang>0)',
-\'command!      -bang -nargs=* History                          call s:history(<q-args>, fzf#vim#with_preview(), <bang>0)'])
+\'command!      -bang -nargs=* History                          call s:history(<q-args>, fzf#vim#with_preview(), <bang>0)',
+\'command!      -bang -nargs=* References                       call fzf#vim#alefindreferences(<q-args>)'])
 
 function! s:history(arg, extra, bang)
   let bang = a:bang || a:arg[len(a:arg)-1] == '!'
@@ -161,4 +162,3 @@ onoremap <silent> <plug>(fzf-maps-o) <c-c>:<c-u>call fzf#vim#maps('o', 0)<cr>
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-


### PR DESCRIPTION
Thanks for the effort in maintaining this extremely useful project and `fzf`.

I recently contributed to [dense-analysis/ale](https://github.com/dense-analysis/ale/) a new feature which allows to search for symbols using `:ALEFindReferences` and pipe the results into `fzf.vim` (https://github.com/dense-analysis/ale/pull/5018)

This looks looks something like this:

[![alefindreferences-fzf](https://github.com/user-attachments/assets/0589db3d-d8b5-46b6-be48-62a9c785d740)](https://asciinema.org/a/GMdCcWESuoxrRNVSmAtWmAPpl)
[link to asciicast](https://asciinema.org/a/GMdCcWESuoxrRNVSmAtWmAPpl)

While I did add some documentation on integration with `fzf.vim` in ALE's docs [here](https://github.com/dense-analysis/ale/blob/8eb4803da99a575bc827a6c814e63b1053b7002f/doc/ale.txt#L4084-L4112), it might be useful to add the `:References` command to `fzf.vim` to invoke the new functionality in ALE. This PR does just that:

- add `:References` command to use `:ALEFindReferences -fzf`
- doc/fzf-vim.txt: reorder commands in alphabetical order
