### PR TITLE
Fix E728 in fzf#vim#colors() when called with a spec dict

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -611,7 +611,7 @@ function! fzf#vim#colors(...)
   \ 'options': ['+m', '--prompt', 'Colors> ']
   \}
 
-  if !a:1 " We can't set up IPC in fullscreen mode in Vim
+  if a:0 && type(a:1) != s:TYPE.dict && !a:1 " We can't set up IPC in fullscreen mode in Vim
     let fifo = fzf#vim#ipc#start({ msg -> execute('colo '.msg) })
     if len(fifo)
       call extend(spec.options, ['--no-tmux', '--no-padding', '--no-margin', '--bind', 'focus:execute-silent:echo {} > '.fifo])


### PR DESCRIPTION
## Problem

`fzf#vim#colors()` throws `E728: Using a Dictionary as a Number` when called with a spec dict as the first argument:

```vim
command! -bang Colors call fzf#vim#colors({'left': '20', 'options': '--reverse' }, <bang>0)
```

Line 614 does `if !a:1` assuming `a:1` is always a number, but the documented API is `fzf#vim#colors([spec dict], [fullscreen bool])`.

## Fix

Add a type check before the boolean test, matching how `s:fzf()` already handles the same varargs pattern:

```vim
if a:0 && type(a:1) != s:TYPE.dict && !a:1
```

Fixes #1610