### PR TITLE
fix: selecting a result fails if its path contains an opening parentheses (Powershell)

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -263,7 +263,11 @@ function! s:chomp(str)
 endfunction
 
 function! s:escape(path)
-  let path = fnameescape(a:path)
+  let path = a:path
+  if s:is_win
+    let path = substitute(path, '\\\ze[()]', '/', 'g')
+  endif
+  let path = fnameescape(path)
   return s:is_win ? escape(path, '$') : path
 endfunction
 


### PR DESCRIPTION
Fixes #1613 
Happened because of insufficient escaping of parentheses in Powershell environments, causing them to be read as Powershell grouping operators