### PR TITLE
Show lua colorschemes in :Colors command

### DIFF
--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -688,11 +688,7 @@ function! s:colors_exit(code)
 endfunction
 
 function! fzf#vim#colors(...)
-  let colors = split(globpath(&rtp, "colors/*.vim"), "\n")
-  if has('packages')
-    let colors += split(globpath(&packpath, "pack/*/opt/*/colors/*.vim"), "\n")
-  endif
-  let colors = fzf#vim#_uniq(map(colors, "fnamemodify(v:val, ':t')[:-5]"))
+  let colors = getcompletion('', 'color')
 
   " Put the current colorscheme at the top
   if exists('g:colors_name')

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -688,7 +688,17 @@ function! s:colors_exit(code)
 endfunction
 
 function! fzf#vim#colors(...)
-  let colors = getcompletion('', 'color')
+  " getcompletion is available from Vim 7.4
+  if exists('*getcompletion')
+    let colors = getcompletion('', 'color')
+  else
+    let colors = split(globpath(&rtp, "colors/*.vim"), "\n")
+    let colors += split(globpath(&rtp, "colors/*.lua"), "\n")
+    if has('packages')
+      let colors += split(globpath(&packpath, "pack/*/opt/*/colors/*.vim"), "\n")
+    endif
+    let colors = fzf#vim#_uniq(map(colors, "fnamemodify(v:val, ':t')[:-5]"))
+  endif
 
   " Put the current colorscheme at the top
   if exists('g:colors_name')

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -693,7 +693,9 @@ function! fzf#vim#colors(...)
     let colors = getcompletion('', 'color')
   else
     let colors = split(globpath(&rtp, "colors/*.vim"), "\n")
-    let colors += split(globpath(&rtp, "colors/*.lua"), "\n")
+    if has('nvim')
+      let colors += split(globpath(&rtp, "colors/*.lua"), "\n")
+    endif
     if has('packages')
       let colors += split(globpath(&packpath, "pack/*/opt/*/colors/*.vim"), "\n")
     endif

--- a/autoload/fzf/vim.vim
+++ b/autoload/fzf/vim.vim
@@ -688,19 +688,7 @@ function! s:colors_exit(code)
 endfunction
 
 function! fzf#vim#colors(...)
-  " getcompletion is available from Vim 7.4
-  if exists('*getcompletion')
-    let colors = getcompletion('', 'color')
-  else
-    let colors = split(globpath(&rtp, "colors/*.vim"), "\n")
-    if has('nvim')
-      let colors += split(globpath(&rtp, "colors/*.lua"), "\n")
-    endif
-    if has('packages')
-      let colors += split(globpath(&packpath, "pack/*/opt/*/colors/*.vim"), "\n")
-    endif
-    let colors = fzf#vim#_uniq(map(colors, "fnamemodify(v:val, ':t')[:-5]"))
-  endif
+  let colors = getcompletion('', 'color')
 
   " Put the current colorscheme at the top
   if exists('g:colors_name')


### PR DESCRIPTION
Problem:
The `:Colors` command only looks for color schemes written in vimscript and not any Neovim lua color schemes.

Fix:
If available use`getcompletion` to get the list of available color schemes. This should be more accurate than globbing the paths.  If `getcompletion` isn't available then fallback to the prior behavior with added support for lua colorschemes.

I would be in favor of removing the fallback completely and just using `getcompletion`, but that would drop support for Vim versions prior to 7.4 when `getcompletion` was added.


Testing:
- [x] neovim 0.12
- [x] vim 9.1
